### PR TITLE
Allow generated IDL files

### DIFF
--- a/rosidl_generator_py/cmake/custom_command.cmake
+++ b/rosidl_generator_py/cmake/custom_command.cmake
@@ -17,7 +17,7 @@ add_custom_command(
   COMMAND ${PYTHON_EXECUTABLE} ${rosidl_generator_py_BIN}
   --generator-arguments-file "${generator_arguments_file}"
   --typesupport-impls "${_typesupport_impls}"
-  DEPENDS ${target_dependencies}
+  DEPENDS ${target_dependencies} ${rosidl_generate_interfaces_TARGET}
   COMMENT "Generating Python code for ROS interfaces"
   VERBATIM
 )

--- a/rosidl_generator_py/cmake/custom_command.cmake
+++ b/rosidl_generator_py/cmake/custom_command.cmake
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Unlike other generators, this custom command depends on the target
+# ${rosidl_generate_interfaces_TARGET} and not the IDL files.
+# The IDL files could be generated files,as they are for .action files.
+# CMake does not allow `add_custom_command()` to depend on files generated in
+# a different CMake subdirectory, and this command is invoked after an
+# add_subdirectory() call.
 add_custom_command(
   OUTPUT ${_generated_extension_files} ${_generated_msg_py_files} ${_generated_msg_c_files} ${_generated_srv_py_files} ${_generated_srv_c_files} ${_generated_action_py_files} ${_generated_action_c_files}
   COMMAND ${PYTHON_EXECUTABLE} ${rosidl_generator_py_BIN}

--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -134,7 +134,6 @@ set(target_dependencies
   "${rosidl_generator_py_TEMPLATE_DIR}/_msg_pkg_typesupport_entry_point.c.em"
   "${rosidl_generator_py_TEMPLATE_DIR}/_msg.py.em"
   "${rosidl_generator_py_TEMPLATE_DIR}/_srv.py.em"
-  ${rosidl_generate_interfaces_IDL_FILES}
   ${_dependency_files})
 foreach(dep ${target_dependencies})
   if(NOT EXISTS "${dep}")


### PR DESCRIPTION
The target dependency won't exist at cmake configure time before the first build if it is generated. Since the custom command is in a subdirectory it cannot depend on the generated files directly. Instead it depends on a target from the parent directory which depends on the IDL files.

connects to ros2/rcl_interfaces#47

