### PR TITLE
Adding a get_slot_fields_and_types method to python msg classes

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -1,4 +1,4 @@
-# generated from rosidl_generator_py/resource/_msg.py.em  # noqa: W504
+# generated from rosidl_generator_py/resource/_msg.py.em
 # generated code does not contain a copyright notice
 
 @#######################################################################
@@ -236,26 +236,26 @@ if field.name in dict(inspect.getmembers(builtins)).keys():
 @[  end if]@
             assert \
 @[  if field.type.is_array]@
-                ((isinstance(value, Sequence) or  # noqa: W504
-                  isinstance(value, Set) or  # noqa: W504
-                  isinstance(value, UserList)) and  # noqa: W504
-                 not isinstance(value, str) and  # noqa: W504
-                 not isinstance(value, UserString) and  # noqa: W504
+                ((isinstance(value, Sequence) or
+                  isinstance(value, Set) or
+                  isinstance(value, UserList)) and
+                 not isinstance(value, str) and
+                 not isinstance(value, UserString) and
 @{assert_msg_suffixes = ['a set or sequence']}@
 @[    if field.type.type == 'string' and field.type.string_upper_bound]@
-                 all(len(val) <= @field.type.string_upper_bound for val in value) and  # noqa: W504
+                 all(len(val) <= @field.type.string_upper_bound for val in value) and
 @{assert_msg_suffixes.append('and each string value not longer than %d' % field.type.string_upper_bound)}@
 @[    end if]@
 @[    if field.type.array_size]@
 @[      if field.type.is_upper_bound]@
-                 len(value) <= @(field.type.array_size) and  # noqa: W504
+                 len(value) <= @(field.type.array_size) and
 @{assert_msg_suffixes.insert(1, 'with length <= %d' % field.type.array_size)}@
 @[      else]@
-                 len(value) == @(field.type.array_size) and  # noqa: W504
+                 len(value) == @(field.type.array_size) and
 @{assert_msg_suffixes.insert(1, 'with length %d' % field.type.array_size)}@
 @[      end if]@
 @[    end if]@
-                 all(isinstance(v, @(get_python_type(field.type))) for v in value) and  # noqa: W504
+                 all(isinstance(v, @(get_python_type(field.type))) for v in value) and
 @{assert_msg_suffixes.append("and each value of type '%s'" % get_python_type(field.type))}@
 @[    if field.type.type.startswith('int')]@
 @{
@@ -279,7 +279,7 @@ bound = 2**nbits
 @[    end if]@
                 "The '@(field.name)' field must be @(' '.join(assert_msg_suffixes))"
 @[  elif field.type.string_upper_bound]@
-                ((isinstance(value, str) or isinstance(value, UserString)) and  # noqa W504
+                ((isinstance(value, str) or isinstance(value, UserString)) and
                  len(value) <= @(field.type.string_upper_bound)), \
                 "The '@(field.name)' field must be string value " \
                 'not longer than @(field.type.string_upper_bound)'
@@ -287,11 +287,11 @@ bound = 2**nbits
                 isinstance(value, @(field.type.type)), \
                 "The '@(field.name)' field must be a sub message of type '@(field.type.type)'"
 @[  elif field.type.type == 'byte']@
-                ((isinstance(value, bytes) or isinstance(value, ByteString)) and  # noqa: W504
+                ((isinstance(value, bytes) or isinstance(value, ByteString)) and
                  len(value) == 1), \
                 "The '@(field.name)' field must of type 'bytes' or 'ByteString' with a length 1"
 @[  elif field.type.type == 'char']@
-                ((isinstance(value, str) or isinstance(value, UserString)) and  # noqa: W504
+                ((isinstance(value, str) or isinstance(value, UserString)) and
                  len(value) == 1 and ord(value) >= -128 and ord(value) < 128), \
                 "The '@(field.name)' field must of type 'str' or 'UserString' " \
                 'with a length 1 and the character ord() in [-128, 127]'

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -1,4 +1,4 @@
-# generated from rosidl_generator_py/resource/_msg.py.em
+# generated from rosidl_generator_py/resource/_msg.py.em  # noqa: W504
 # generated code does not contain a copyright notice
 
 @#######################################################################
@@ -14,6 +14,7 @@
 @#  - value_to_py (function)
 @#######################################################################
 @
+from copy import copy
 import logging
 import traceback
 
@@ -114,6 +115,28 @@ class @(spec.base_type.type)(metaclass=Metaclass):
         '_@(field.name)',
 @[end for]@
     ]
+
+    _fields_and_field_types = {
+@[for field in spec.fields]@
+@[  if field.type.is_primitive_type() ]@
+        '@(field.name)': '@(field.type)',
+@[  else ]@
+@[    if field.type.is_array ]@
+@[      if field.type.array_size ]@
+@[        if field.type.is_upper_bound ]@
+        '@(field.name)': '@(field.type.pkg_name)/@(field.type.type)[<=@(field.type.array_size)]',
+@[        else ]@
+        '@(field.name)': '@(field.type.pkg_name)/@(field.type.type)[@(field.type.array_size)]',
+@[        end if ]@
+@[      else ]@
+        '@(field.name)': '@(field.type.pkg_name)/@(field.type.type)[]',
+@[      end if ]@
+@[    else ]@
+        '@(field.name)': '@(field.type.pkg_name)/@(field.type.type)',
+@[    end if ]@
+@[  end if ]@
+@[end for]@
+    }
 @
 @[if len(spec.fields) > 0]@
 
@@ -175,6 +198,10 @@ class @(spec.base_type.type)(metaclass=Metaclass):
             return False
 @[end for]@
         return True
+
+    @@classmethod
+    def get_fields_and_field_types(cls):
+        return copy(cls._fields_and_field_types)
 @[for field in spec.fields]@
 
 @{
@@ -209,26 +236,26 @@ if field.name in dict(inspect.getmembers(builtins)).keys():
 @[  end if]@
             assert \
 @[  if field.type.is_array]@
-                ((isinstance(value, Sequence) or
-                  isinstance(value, Set) or
-                  isinstance(value, UserList)) and
-                 not isinstance(value, str) and
-                 not isinstance(value, UserString) and
+                ((isinstance(value, Sequence) or  # noqa: W504
+                  isinstance(value, Set) or  # noqa: W504
+                  isinstance(value, UserList)) and  # noqa: W504
+                 not isinstance(value, str) and  # noqa: W504
+                 not isinstance(value, UserString) and  # noqa: W504
 @{assert_msg_suffixes = ['a set or sequence']}@
 @[    if field.type.type == 'string' and field.type.string_upper_bound]@
-                 all(len(val) <= @field.type.string_upper_bound for val in value) and
+                 all(len(val) <= @field.type.string_upper_bound for val in value) and  # noqa: W504
 @{assert_msg_suffixes.append('and each string value not longer than %d' % field.type.string_upper_bound)}@
 @[    end if]@
 @[    if field.type.array_size]@
 @[      if field.type.is_upper_bound]@
-                 len(value) <= @(field.type.array_size) and
+                 len(value) <= @(field.type.array_size) and  # noqa: W504
 @{assert_msg_suffixes.insert(1, 'with length <= %d' % field.type.array_size)}@
 @[      else]@
-                 len(value) == @(field.type.array_size) and
+                 len(value) == @(field.type.array_size) and  # noqa: W504
 @{assert_msg_suffixes.insert(1, 'with length %d' % field.type.array_size)}@
 @[      end if]@
 @[    end if]@
-                 all(isinstance(v, @(get_python_type(field.type))) for v in value) and
+                 all(isinstance(v, @(get_python_type(field.type))) for v in value) and  # noqa: W504
 @{assert_msg_suffixes.append("and each value of type '%s'" % get_python_type(field.type))}@
 @[    if field.type.type.startswith('int')]@
 @{
@@ -252,7 +279,7 @@ bound = 2**nbits
 @[    end if]@
                 "The '@(field.name)' field must be @(' '.join(assert_msg_suffixes))"
 @[  elif field.type.string_upper_bound]@
-                ((isinstance(value, str) or isinstance(value, UserString)) and
+                ((isinstance(value, str) or isinstance(value, UserString)) and  # noqa W504
                  len(value) <= @(field.type.string_upper_bound)), \
                 "The '@(field.name)' field must be string value " \
                 'not longer than @(field.type.string_upper_bound)'
@@ -260,11 +287,11 @@ bound = 2**nbits
                 isinstance(value, @(field.type.type)), \
                 "The '@(field.name)' field must be a sub message of type '@(field.type.type)'"
 @[  elif field.type.type == 'byte']@
-                ((isinstance(value, bytes) or isinstance(value, ByteString)) and
+                ((isinstance(value, bytes) or isinstance(value, ByteString)) and  # noqa: W504
                  len(value) == 1), \
                 "The '@(field.name)' field must of type 'bytes' or 'ByteString' with a length 1"
 @[  elif field.type.type == 'char']@
-                ((isinstance(value, str) or isinstance(value, UserString)) and
+                ((isinstance(value, str) or isinstance(value, UserString)) and  # noqa: W504
                  len(value) == 1 and ord(value) >= -128 and ord(value) < 128), \
                 "The '@(field.name)' field must of type 'str' or 'UserString' " \
                 'with a length 1 and the character ord() in [-128, 127]'

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -257,3 +257,60 @@ def test_out_of_range():
         setattr(b, 'unbounded_uint64_values', [2**64])
     with pytest.raises(AssertionError):
         setattr(b, 'unbounded_uint64_values', [-1])
+
+
+def test_slot_attributes():
+    a = Nested()
+    assert hasattr(a, 'get_fields_and_field_types')
+    assert hasattr(a, '__slots__')
+    nested_slot_types_dict = getattr(a, 'get_fields_and_field_types')()
+    nested_slots = getattr(a, '__slots__')
+    assert len(nested_slot_types_dict) == len(nested_slots)
+    expected_nested_slot_types_dict = {
+        'primitives': 'rosidl_generator_py/Primitives',
+        'two_primitives': 'rosidl_generator_py/Primitives[2]',
+        'up_to_three_primitives': 'rosidl_generator_py/Primitives[<=3]',
+        'unbounded_primitives': 'rosidl_generator_py/Primitives[]',
+    }
+    assert len(nested_slot_types_dict) == len(expected_nested_slot_types_dict)
+
+    for expected_field, expected_slot_type in expected_nested_slot_types_dict.items():
+        assert expected_field in nested_slot_types_dict.keys()
+        assert expected_slot_type == nested_slot_types_dict[expected_field]
+
+
+def test_primative_slot_attributes():
+    b = StringArrays()
+    assert hasattr(b, 'get_fields_and_field_types')
+    assert hasattr(b, '__slots__')
+    string_slot_types_dict = getattr(b, 'get_fields_and_field_types')()
+    string_slots = getattr(b, '__slots__')
+    assert len(string_slot_types_dict) == len(string_slots)
+    expected_string_slot_types_dict = {
+        'ub_string_static_array_value': 'string<=5[3]',
+        'ub_string_ub_array_value': 'string<=5[<=10]',
+        'ub_string_dynamic_array_value': 'string<=5[]',
+        'string_dynamic_array_value': 'string[]',
+        'string_static_array_value': 'string[3]',
+        'string_bounded_array_value': 'string[<=10]',
+        'def_string_dynamic_array_value': 'string[]',
+        'def_string_static_array_value': 'string[3]',
+        'def_string_bounded_array_value': 'string[<=10]',
+        'def_various_quotes': 'string[]',
+        'def_various_commas': 'string[]',
+    }
+
+    assert len(string_slot_types_dict) == len(expected_string_slot_types_dict)
+
+    for expected_field, expected_slot_type in expected_string_slot_types_dict.items():
+        assert expected_field in string_slot_types_dict.keys()
+        assert expected_slot_type == string_slot_types_dict[expected_field]
+
+
+def test_modifying_slot_fields_and_types():
+    b = StringArrays()
+    assert hasattr(b, 'get_fields_and_field_types')
+    string_slot_types_dict = getattr(b, 'get_fields_and_field_types')()
+    string_slot_types_dict_len = len(string_slot_types_dict)
+    string_slot_types_dict[1] = 2
+    assert len(getattr(b, 'get_fields_and_field_types')()) == string_slot_types_dict_len


### PR DESCRIPTION
This adds a `_slot_types` field to python message classes as was requested here: https://github.com/ros2/rosidl_python/issues/16

This attempts to remain as true to the ROS1 functionality as possible