### PR TITLE
map Arrays to numpy.ndarray() and Sequences to array.array()

### DIFF
--- a/rosidl_generator_py/CMakeLists.txt
+++ b/rosidl_generator_py/CMakeLists.txt
@@ -53,7 +53,7 @@ if(BUILD_TESTING)
   # Need to call extras before get_typesupports, to register the extension
   rosidl_generator_py_extras(
     "${CMAKE_CURRENT_SOURCE_DIR}/bin/rosidl_generator_py"
-    "${CMAKE_CURRENT_SOURCE_DIR}/rosidl_generator_py/__init__.py"
+    "${CMAKE_CURRENT_SOURCE_DIR}/rosidl_generator_py/__init__.py;${CMAKE_CURRENT_SOURCE_DIR}/rosidl_generator_py/generate_py_impl.py"
     "${CMAKE_CURRENT_SOURCE_DIR}/resource"
   )
 

--- a/rosidl_generator_py/cmake/register_py.cmake
+++ b/rosidl_generator_py/cmake/register_py.cmake
@@ -22,8 +22,11 @@ macro(rosidl_generator_py_extras BIN GENERATOR_FILES TEMPLATE_DIR)
   normalize_path(BIN "${BIN}")
   set(rosidl_generator_py_BIN "${BIN}")
 
-  normalize_path(GENERATOR_FILES "${GENERATOR_FILES}")
-  set(rosidl_generator_py_GENERATOR_FILES "${GENERATOR_FILES}")
+  set(rosidl_generator_py_GENERATOR_FILES "")
+  foreach(_generator_file ${GENERATOR_FILES})
+    normalize_path(_generator_file "${_generator_file}")
+    list(APPEND rosidl_generator_py_GENERATOR_FILES "${_generator_file}")
+  endforeach()
 
   normalize_path(TEMPLATE_DIR "${TEMPLATE_DIR}")
   set(rosidl_generator_py_TEMPLATE_DIR "${TEMPLATE_DIR}")

--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -185,6 +185,25 @@ target_include_directories(${_target_name_lib}
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py
   ${PythonExtra_INCLUDE_DIRS}
 )
+if(APPLE OR WIN32)
+  # add include directory for numpy headers
+  set(_python_code
+    "import numpy"
+    "print(numpy.get_include())"
+  )
+  execute_process(
+    COMMAND "${PYTHON_EXECUTABLE}" "-c" "${_python_code}"
+    OUTPUT_VARIABLE _output
+    RESULT_VARIABLE _result
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if(NOT _result EQUAL 0)
+    message(FATAL_ERROR
+      "execute_process(${PYTHON_EXECUTABLE} -c '${_python_code}') returned "
+      "error code ${_result}")
+  endif()
+  target_include_directories(${_target_name_lib} PUBLIC "${_output}")
+endif()
 
 rosidl_target_interfaces(${_target_name_lib}
   ${rosidl_generate_interfaces_TARGET} rosidl_typesupport_c)

--- a/rosidl_generator_py/resource/_action.py.em
+++ b/rosidl_generator_py/resource/_action.py.em
@@ -8,27 +8,27 @@ module_name = '_' + convert_camel_case_to_lower_case_underscore(interface_path.s
 TEMPLATE(
     '_msg.py.em',
     package_name=package_name, interface_path=interface_path,
-    message=action.goal)
+    message=action.goal, import_statements=import_statements)
 TEMPLATE(
     '_msg.py.em',
     package_name=package_name, interface_path=interface_path,
-    message=action.result)
+    message=action.result, import_statements=import_statements)
 TEMPLATE(
     '_msg.py.em',
     package_name=package_name, interface_path=interface_path,
-    message=action.feedback)
+    message=action.feedback, import_statements=import_statements)
 TEMPLATE(
     '_srv.py.em',
     package_name=package_name, interface_path=interface_path,
-    service=action.send_goal_service)
+    service=action.send_goal_service, import_statements=import_statements)
 TEMPLATE(
     '_srv.py.em',
     package_name=package_name, interface_path=interface_path,
-    service=action.get_result_service)
+    service=action.get_result_service, import_statements=import_statements)
 TEMPLATE(
     '_msg.py.em',
     package_name=package_name, interface_path=interface_path,
-    message=action.feedback_message)
+    message=action.feedback_message, import_statements=import_statements)
 }@
 
 

--- a/rosidl_generator_py/resource/_idl.py.em
+++ b/rosidl_generator_py/resource/_idl.py.em
@@ -10,6 +10,9 @@
 @#  - interface_path (Path relative to the directory named after the package)
 @#  - content (IdlContent, list of elements, e.g. Messages or Services)
 @#######################################################################
+@{
+import_statements = set()
+}@
 @
 @#######################################################################
 @# Handle messages
@@ -21,8 +24,8 @@ from rosidl_parser.definition import Message
 @{
 TEMPLATE(
     '_msg.py.em',
-    package_name=package_name, interface_path=interface_path,
-    message=message)
+    package_name=package_name, interface_path=interface_path, message=message,
+    import_statements=import_statements)
 }@
 @[end for]@
 @
@@ -36,7 +39,8 @@ from rosidl_parser.definition import Service
 @{
 TEMPLATE(
     '_srv.py.em',
-    package_name=package_name, interface_path=interface_path, service=service)
+    package_name=package_name, interface_path=interface_path, service=service,
+    import_statements=import_statements)
 }@
 @[end for]@
 @
@@ -50,6 +54,7 @@ from rosidl_parser.definition import Action
 @{
 TEMPLATE(
     '_action.py.em',
-    package_name=package_name, interface_path=interface_path, action=action)
+    package_name=package_name, interface_path=interface_path, action=action,
+    import_statements=import_statements)
 }@
 @[end for]@

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -394,15 +394,15 @@ bound = 2**nbits
 @[  elif isinstance(type_, BasicType) and type_.type == 'octet']@
                 ((isinstance(value, bytes) or isinstance(value, ByteString)) and
                  len(value) == 1), \
-                "The '@(member.name)' field must of type 'bytes' or 'ByteString' with a length 1"
+                "The '@(member.name)' field must be of type 'bytes' or 'ByteString' with length 1"
 @[  elif isinstance(type_, BasicType) and type_.type == 'char']@
                 ((isinstance(value, str) or isinstance(value, UserString)) and
                  len(value) == 1 and ord(value) >= -128 and ord(value) < 128), \
-                "The '@(member.name)' field must of type 'str' or 'UserString' " \
-                'with a length 1 and the character ord() in [-128, 127]'
+                "The '@(member.name)' field must be of type 'str' or 'UserString' " \
+                'with length 1 and the character ord() in [-128, 127]'
 @[  elif isinstance(type_, BaseString)]@
                 isinstance(value, str), \
-                "The '@(member.name)' field must of type '@(get_python_type(type_))'"
+                "The '@(member.name)' field must be of type '@(get_python_type(type_))'"
 @[  elif isinstance(type_, BasicType) and type_.type in [
         'boolean',
         'float', 'double',
@@ -412,7 +412,7 @@ bound = 2**nbits
         'int64', 'uint64',
     ]]@
                 isinstance(value, @(get_python_type(type_))), \
-                "The '@(member.name)' field must of type '@(get_python_type(type_))'"
+                "The '@(member.name)' field must be of type '@(get_python_type(type_))'"
 @[    if type_.type.startswith('int')]@
 @{
 nbits = int(type_.type[3:])

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -299,7 +299,11 @@ if isinstance(type_, NestedType):
         if not isinstance(other, self.__class__):
             return False
 @[for member in message.structure.members]@
+@[  if isinstance(member.type, Array) and isinstance(member.type.basetype, BasicType) and member.type.basetype.type in SPECIAL_NESTED_BASIC_TYPES]@
+        if all(self.@(member.name) != other.@(member.name)):
+@[  else]@
         if self.@(member.name) != other.@(member.name):
+@[  end if]@
             return False
 @[end for]@
         return True

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -18,6 +18,52 @@ from rosidl_parser.definition import Sequence
 from rosidl_parser.definition import String
 from rosidl_parser.definition import WString
 }@
+@#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+@# Collect necessary import statements for all members
+@{
+from collections import OrderedDict
+import numpy
+imports = OrderedDict()
+for member in message.structure.members:
+    if (
+        isinstance(member.type, NestedType) and
+        isinstance(member.type.basetype, BasicType) and
+        member.type.basetype.type in SPECIAL_NESTED_BASIC_TYPES
+    ):
+        if isinstance(member.type, Array):
+            member_names = imports.setdefault(
+                'import numpy', [])
+        elif isinstance(member.type, Sequence):
+            member_names = imports.setdefault(
+                'import array', [])
+        else:
+            assert False
+        member_names.append(member.name)
+}@
+@#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+@
+@#<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+@[if imports]@
+
+
+# Import statements for member types
+@[    for import_statement, member_names in sorted(imports.items())]@
+
+@[        for member_name in member_names]@
+# Member '@(member_name)'
+@[        end for]@
+@[        if import_statement in import_statements]@
+# already imported above
+# @
+@[        end if]@
+@(import_statement)@
+@[        if import_statement not in import_statements]@
+@{import_statements.add(import_statement)}@
+  # noqa: E402@
+@[        end if]
+@[    end for]@
+@[end if]@
+@#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 
 class Metaclass_@(message.structure.type.name)(type):

--- a/rosidl_generator_py/resource/_srv.py.em
+++ b/rosidl_generator_py/resource/_srv.py.em
@@ -8,11 +8,11 @@ module_name = '_' + convert_camel_case_to_lower_case_underscore(interface_path.s
 TEMPLATE(
     '_msg.py.em',
     package_name=package_name, interface_path=interface_path,
-    message=service.request_message)
+    message=service.request_message, import_statements=import_statements)
 TEMPLATE(
     '_msg.py.em',
     package_name=package_name, interface_path=interface_path,
-    message=service.response_message)
+    message=service.response_message, import_statements=import_statements)
 }@
 
 

--- a/rosidl_generator_py/rosidl_generator_py-extras.cmake.in
+++ b/rosidl_generator_py/rosidl_generator_py-extras.cmake.in
@@ -2,6 +2,6 @@
 include("${CMAKE_CURRENT_LIST_DIR}/register_py.cmake")
 rosidl_generator_py_extras(
   "${rosidl_generator_py_DIR}/../../../lib/rosidl_generator_py/rosidl_generator_py"
-  "${rosidl_generator_py_DIR}/../../../@PYTHON_INSTALL_DIR@/rosidl_generator_py/__init__.py"
+  "${rosidl_generator_py_DIR}/../../../@PYTHON_INSTALL_DIR@/rosidl_generator_py/__init__.py;${rosidl_generator_py_DIR}/../../../@PYTHON_INSTALL_DIR@/rosidl_generator_py/generate_py_impl.py"
   "${rosidl_generator_py_DIR}/../resource"
 )

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
+import array
 
+import numpy
+import pytest
 from rosidl_generator_py.msg import Constants
 from rosidl_generator_py.msg import Nested
 from rosidl_generator_py.msg import Primitives
@@ -128,9 +130,17 @@ def test_default_values():
     assert ['Hel,lo', ',World', 'abcd', '!,'] == b.DEF_VARIOUS_COMMAS__DEFAULT
 
     c = Various()
-    assert [5, 23] == c.TWO_UINT16_VALUE__DEFAULT
+    assert isinstance(c.TWO_UINT16_VALUE__DEFAULT, numpy.ndarray)
+    assert (2, ) == c.TWO_UINT16_VALUE__DEFAULT.shape
+    assert numpy.uint16 == c.TWO_UINT16_VALUE__DEFAULT.dtype
+    assert [5, 23] == c.TWO_UINT16_VALUE__DEFAULT.tolist()
 
-    assert [5, 23] == c.UP_TO_THREE_INT32_VALUES_WITH_DEFAULT_VALUES__DEFAULT
+    assert isinstance(
+        c.UP_TO_THREE_INT32_VALUES_WITH_DEFAULT_VALUES__DEFAULT, array.array)
+    assert 'i' == \
+        c.UP_TO_THREE_INT32_VALUES_WITH_DEFAULT_VALUES__DEFAULT.typecode
+    assert [5, 23] == \
+        c.UP_TO_THREE_INT32_VALUES_WITH_DEFAULT_VALUES__DEFAULT.tolist()
 
     assert 1 == c.CHAR_VALUE__DEFAULT
     assert '1' != c.CHAR_VALUE__DEFAULT
@@ -209,11 +219,11 @@ def test_check_constraints():
         setattr(c, 'char_value', b'abc')
 
     c.up_to_three_int32_values = []
-    assert [] == c.up_to_three_int32_values
+    assert [] == c.up_to_three_int32_values.tolist()
     c.up_to_three_int32_values = [12345, -12345]
-    assert [12345, -12345] == c.up_to_three_int32_values
+    assert [12345, -12345] == c.up_to_three_int32_values.tolist()
     c.up_to_three_int32_values = [12345, -12345, 6789]
-    assert [12345, -12345, 6789] == c.up_to_three_int32_values
+    assert [12345, -12345, 6789] == c.up_to_three_int32_values.tolist()
     c.up_to_three_int32_values = [12345, -12345, 6789]
     with pytest.raises(AssertionError):
         setattr(c, 'up_to_three_int32_values', [12345, -12345, 6789, -6789])


### PR DESCRIPTION
Implements the latest version of the design article describing the type mapping for Python (including the latest change ros2/design#217).

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6524)](http://ci.ros2.org/job/ci_linux/6524/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2866)](http://ci.ros2.org/job/ci_linux-aarch64/2866/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5342)](http://ci.ros2.org/job/ci_osx/5342/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6316)](http://ci.ros2.org/job/ci_windows/6316/)