### PR TITLE
Add numpy dependency to package.xml.

### DIFF
--- a/rosidl_generator_py/package.xml
+++ b/rosidl_generator_py/package.xml
@@ -20,6 +20,8 @@
   <buildtool_export_depend>rosidl_typesupport_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_typesupport_interface</buildtool_export_depend>
 
+  <depend>python3-numpy</depend>
+
   <exec_depend>rmw_implementation</exec_depend>
   <exec_depend>rmw_implementation_cmake</exec_depend>
   <exec_depend>rosidl_generator_c</exec_depend>


### PR DESCRIPTION
The build is currently failing due to the numpy import in the template
http://build.ros2.orgjob/Dbin_uB64__rosidl_generator_py__ubuntu_bionic_amd64__binary/1/console

```
06:05:10 [ 89%] Generating Python code for ROS interfaces
06:05:10 cd /tmp/binarydeb/ros-dashing-rosidl-generator-py-0.7.0/obj-x86_64-linux-gnu/rosidl_generator_py_custom__py && /usr/bin/python3 /tmp/binarydeb/ros-dashing-rosidl-generator-py-0.7.0/bin/rosidl_generator_py --generator-arguments-file /tmp/binarydeb/ros-dashing-rosidl-generator-py-0.7.0/obj-x86_64-linux-gnu/rosidl_generator_py__arguments.json --typesupport-impls "rosidl_typesupport_c;rosidl_typesupport_fastrtps_c;rosidl_typesupport_opensplice_c"
06:05:10 ModuleNotFoundError in template '/tmp/binarydeb/ros-dashing-rosidl-generator-py-0.7.0/resource/_msg.py.em': No module named 'numpy'
06:05:10 ModuleNotFoundError when expanding '_idl.py.em' into '/tmp/binarydeb/ros-dashing-rosidl-generator-py-0.7.0/obj-x86_64-linux-gnu/rosidl_generator_py/rosidl_generator_py/msg/_constants.py': No module named 'numpy'
06:05:10 Error processing idl file: /tmp/binarydeb/ros-dashing-rosidl-generator-py-0.7.0/obj-x86_64-linux-gnu/rosidl_adapter/rosidl_generator_py/msg/Constants.idl
06:05:10 Traceback (most recent call last):
06:05:10   File "/tmp/binarydeb/ros-dashing-rosidl-generator-py-0.7.0/bin/rosidl_generator_py", line 40, in <module>
06:05:10     sys.exit(main())
06:05:10   File "/tmp/binarydeb/ros-dashing-rosidl-generator-py-0.7.0/bin/rosidl_generator_py", line 36, in main
06:05:10     return generate_py(args.generator_arguments_file, args.typesupport_impls.split(';'))
06:05:10   File "/tmp/binarydeb/ros-dashing-rosidl-generator-py-0.7.0/rosidl_generator_py/generate_py_impl.py", line 53, in generate_py
06:05:10     generate_files(generator_arguments_file, mapping)
06:05:10   File "/opt/ros/dashing/lib/python3.6/site-packages/rosidl_cmake/__init__.py", line 121, in generate_files
06:05:10     raise(e)
06:05:10   File "/opt/ros/dashing/lib/python3.6/site-packages/rosidl_cmake/__init__.py", line 116, in generate_files
06:05:10     template_basepath=template_basepath)
06:05:10   File "/opt/ros/dashing/lib/python3.6/site-packages/rosidl_cmake/__init__.py", line 175, in expand_template
06:05:10     interpreter.string(template_content, template_path, locals=data)
06:05:10   File "/usr/lib/python3/dist-packages/em.py", line 2391, in string
06:05:10     self.safe(scanner, True, locals)
06:05:10   File "/usr/lib/python3/dist-packages/em.py", line 2401, in safe
06:05:10     self.parse(scanner, locals)
06:05:10   File "/usr/lib/python3/dist-packages/em.py", line 2421, in parse
06:05:10     token.run(self, locals)
06:05:10   File "/usr/lib/python3/dist-packages/em.py", line 1547, in run
06:05:10     self.subrun(info[0][1], interpreter, locals)
06:05:10   File "/usr/lib/python3/dist-packages/em.py", line 1631, in subrun
06:05:10     token.run(interpreter, locals)
06:05:10   File "/usr/lib/python3/dist-packages/em.py", line 1425, in run
06:05:10     interpreter.execute(self.code, locals)
06:05:10   File "/usr/lib/python3/dist-packages/em.py", line 2595, in execute
06:05:10     _exec(statements, self.globals, locals)
06:05:10   File "<string>", line 5, in <module>
06:05:10   File "/opt/ros/dashing/lib/python3.6/site-packages/rosidl_cmake/__init__.py", line 221, in _expand_template
06:05:10     interpreter.string(content, str(template_path), kwargs)
06:05:10   File "/usr/lib/python3/dist-packages/em.py", line 2391, in string
06:05:10     self.safe(scanner, True, locals)
06:05:10   File "/usr/lib/python3/dist-packages/em.py", line 2401, in safe
06:05:10     self.parse(scanner, locals)
06:05:10   File "/usr/lib/python3/dist-packages/em.py", line 2421, in parse
06:05:10     token.run(self, locals)
06:05:10   File "/usr/lib/python3/dist-packages/em.py", line 1425, in run
06:05:10     interpreter.execute(self.code, locals)
06:05:10   File "/usr/lib/python3/dist-packages/em.py", line 2595, in execute
06:05:10     _exec(statements, self.globals, locals)
06:05:10   File "<string>", line 3, in <module>
06:05:10 ModuleNotFoundError: No module named 'numpy'
06:05:10 Exception ignored in: <bound method Interpreter.__del__ of <empy pseudomodule/interpreter at 0x7f83fd338ba8>>
06:05:10 Traceback (most recent call last):
06:05:10   File "/usr/lib/python3/dist-packages/em.py", line 2094, in __del__
06:05:10   File "/usr/lib/python3/dist-packages/em.py", line 2157, in shutdown
06:05:10   File "/usr/lib/python3/dist-packages/em.py", line 2646, in finalize
06:05:10   File "/usr/lib/python3/dist-packages/em.py", line 2200, in push
06:05:10 AttributeError: '_io.TextIOWrapper' object has no attribute 'push'
```

I'm not sure of the proper scope for this dependency so for this PR I've
opted to make it a blanket dependency in order to proceed with the
release absent feedback.