### PR TITLE
remove obsolete argument mod_prefix

### DIFF
--- a/rosidl_generator_py/rosidl_generator_py/import_type_support_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/import_type_support_impl.py
@@ -24,7 +24,7 @@ class UnsupportedTypeSupport(Exception):
         self.pkg_name = pkg_name
 
 
-def import_type_support(pkg_name, mod_prefix=None):
+def import_type_support(pkg_name):
     """
     Import the rosidl_typesupport_c module of a package.
 
@@ -33,12 +33,9 @@ def import_type_support(pkg_name, mod_prefix=None):
     be converted to and from message structures used by the rmw implementation.
 
     :param pkg_name str: name of the package
-    :param mod_prefix str: optional typesupport module prefix
     :returns: the typesupport Python module for the specified package
     """
-    if not mod_prefix:
-        mod_prefix = pkg_name
-    module_name = '.{}_s__rosidl_typesupport_c'.format(mod_prefix)
+    module_name = '.{}_s__rosidl_typesupport_c'.format(pkg_name)
     try:
         return importlib.import_module(module_name, package=pkg_name)
     except ImportError:


### PR DESCRIPTION
Added in #21 specifically for actions the keyword argument is not used anymore.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6692)](https://ci.ros2.org/job/ci_linux/6692/)