### PR TITLE
Fix quoted strings for new flake8-quote check.

### DIFF
--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -114,9 +114,9 @@ def test_default_values():
     assert 'Hello world!' == Strings.DEF_STRING__DEFAULT
     assert 'Hello world!' == a.DEF_STRING__DEFAULT
 
-    assert 'Hello\'world!' == a.DEF_STRING2__DEFAULT
+    assert "Hello'world!" == a.DEF_STRING2__DEFAULT
     assert 'Hello"world!' == a.DEF_STRING3__DEFAULT
-    assert 'Hello\'world!' == a.DEF_STRING4__DEFAULT
+    assert "Hello'world!" == a.DEF_STRING4__DEFAULT
     assert 'Hello"world!' == a.DEF_STRING5__DEFAULT
     with pytest.raises(AttributeError):
         setattr(Strings, 'DEF_STRING__DEFAULT', 'bar')


### PR DESCRIPTION
Note that for generated code, we unconditionally disable the
flake8-quote check Q003 (Change outer quotes to avoid escaping
inner quotes).  For non-string types, this will have no effect.
For string types, it could be fairly expensive to scan strings
for single or double quotes.  The expense just doesn't seem
worth it and the resulting return value won't be exactly what
the user typed into their .msg file.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Connects to https://github.com/ros2/build_cop/issues/179