### PR TITLE
use quotes with least escaping for Python string literals

### DIFF
--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -146,7 +146,7 @@ def primitive_value_to_py(type_, value):
     assert value is not None
 
     if isinstance(type_, String):
-        return quoted_escaped_string(value)
+        return quoted_string(value)
 
     assert isinstance(type_, BasicType)
 
@@ -198,12 +198,12 @@ def constant_value_to_py(type_, value):
             return '%s' % value
 
     if isinstance(type_, String):
-        return quoted_escaped_string(value)
+        return quoted_string(value)
 
     assert False, "unknown constant type '%s'" % type_
 
 
-def quoted_escaped_string(s):
+def quoted_string(s):
     s = s.replace('\\', '\\\\')
     # strings containing single quote but no double quotes can be wrapped in
     # double quotes without escaping

--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -146,7 +146,7 @@ def primitive_value_to_py(type_, value):
     assert value is not None
 
     if isinstance(type_, String):
-        return "'%s'" % escape_string(value)
+        return quoted_escaped_string(value)
 
     assert isinstance(type_, BasicType)
 
@@ -198,15 +198,21 @@ def constant_value_to_py(type_, value):
             return '%s' % value
 
     if isinstance(type_, String):
-        return "'%s'" % escape_string(value)
+        return quoted_escaped_string(value)
 
     assert False, "unknown constant type '%s'" % type_
 
 
-def escape_string(s):
+def quoted_escaped_string(s):
     s = s.replace('\\', '\\\\')
+    # strings containing single quote but no double quotes can be wrapped in
+    # double quotes without escaping
+    if "'" in s and '"' not in s:
+        return '"%s"' % s
+    # all other strings are wrapped in single quotes, if necessary with escaped
+    # single quotes
     s = s.replace("'", "\\'")
-    return s
+    return "'%s'" % s
 
 
 def get_python_type(type_):


### PR DESCRIPTION
Replaces parts of #42.

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6735)](https://ci.ros2.org/job/ci_linux/6735/) (8 test failures)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6736)](https://ci.ros2.org/job/ci_linux/6736/) (3 test failures)