### PR TITLE
Use semantic exec_depend key for python3-numpy.

### DIFF
--- a/rosidl_generator_py/package.xml
+++ b/rosidl_generator_py/package.xml
@@ -20,8 +20,8 @@
   <buildtool_export_depend>rosidl_typesupport_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_typesupport_interface</buildtool_export_depend>
 
-  <depend>python3-numpy</depend>
 
+  <exec_depend>python3-numpy</exec_depend>
   <exec_depend>rmw_implementation</exec_depend>
   <exec_depend>rmw_implementation_cmake</exec_depend>
   <exec_depend>rosidl_generator_c</exec_depend>


### PR DESCRIPTION
Follow up from #39.