### PR TITLE
allow unicode chars in yaml output

### DIFF
--- a/rosidl_runtime_py/rosidl_runtime_py/convert.py
+++ b/rosidl_runtime_py/rosidl_runtime_py/convert.py
@@ -51,7 +51,7 @@ def message_to_yaml(msg: Any, truncate_length: int = None) -> str:
 
     return yaml.dump(
         message_to_ordereddict(msg, truncate_length=truncate_length),
-        width=sys.maxsize,
+        allow_unicode=True, width=sys.maxsize,
     )
 
 


### PR DESCRIPTION
Related to ros2/ros2cli#154.

This makes the output of e.g. `ros2 topic echo ...` much easier to read:

* before: `wstring_value: "Hell\xF6 W\xF6rld!"`
* after: `wstring_value: Hellö Wörld!`