### PR TITLE
add missing numpy test dependency

### DIFF
--- a/rosidl_generator_py/package.xml
+++ b/rosidl_generator_py/package.xml
@@ -31,6 +31,7 @@
   <test_depend>ament_index_python</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>python3-numpy</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>python_cmake_module</test_depend>
   <test_depend>rmw</test_depend>


### PR DESCRIPTION
Fixes missing dependency.

http://build.ros2.org/view/Dbin_uB64/job/Dbin_uB64__rosidl_generator_py__ubuntu_bionic_amd64__binary/14/