### PR TITLE
encode/decode strings with UTF-8

### DIFF
--- a/rosidl_generator_py/resource/_msg_support.c.em
+++ b/rosidl_generator_py/resource/_msg_support.c.em
@@ -321,7 +321,7 @@ nested_type = '__'.join(type_.namespaced_name())
       Py_DECREF(encoded_item);
 @[    elif isinstance(member.type.value_type, AbstractWString)]@
       assert(PyUnicode_Check(item));
-      // the returned string starts with a BOM mark
+      // the returned string starts with a BOM mark and uses native byte order
       PyObject * encoded_item = PyUnicode_AsUTF16String(item);
       if (!encoded_item) {
         Py_DECREF(seq_field);
@@ -407,7 +407,7 @@ nested_type = '__'.join(type_.namespaced_name())
     Py_DECREF(encoded_field);
 @[  elif isinstance(member.type, AbstractWString)]@
     assert(PyUnicode_Check(field));
-    // the returned string starts with a BOM mark
+    // the returned string starts with a BOM mark and uses native byte order
     PyObject * encoded_field = PyUnicode_AsUTF16String(field);
     if (!encoded_field) {
       Py_DECREF(field);

--- a/rosidl_generator_py/resource/_msg_support.c.em
+++ b/rosidl_generator_py/resource/_msg_support.c.em
@@ -298,7 +298,7 @@ nested_type = '__'.join(type_.namespaced_name())
       @primitive_msg_type_to_c(member.type.value_type) tmp = *(@(SPECIAL_NESTED_BASIC_TYPES[member.type.value_type.typename]['dtype'].replace('numpy.', 'npy_')) *)PyArray_GETPTR1(seq_field, i);
 @[    elif isinstance(member.type.value_type, BasicType) and member.type.value_type.typename == 'char']@
       assert(PyUnicode_Check(item));
-      PyObject * encoded_item = PyUnicode_AsASCIIString(item);
+      PyObject * encoded_item = PyUnicode_AsUTF8String(item);
       if (!encoded_item) {
         Py_DECREF(seq_field);
         Py_DECREF(field);
@@ -311,7 +311,7 @@ nested_type = '__'.join(type_.namespaced_name())
       @primitive_msg_type_to_c(member.type.value_type) tmp = PyBytes_AS_STRING(item)[0];
 @[    elif isinstance(member.type.value_type, AbstractString)]@
       assert(PyUnicode_Check(item));
-      PyObject * encoded_item = PyUnicode_AsASCIIString(item);
+      PyObject * encoded_item = PyUnicode_AsUTF8String(item);
       if (!encoded_item) {
         Py_DECREF(seq_field);
         Py_DECREF(field);
@@ -386,7 +386,7 @@ nested_type = '__'.join(type_.namespaced_name())
     Py_DECREF(seq_field);
 @[  elif isinstance(member.type, BasicType) and member.type.typename == 'char']@
     assert(PyUnicode_Check(field));
-    PyObject * encoded_field = PyUnicode_AsASCIIString(field);
+    PyObject * encoded_field = PyUnicode_AsUTF8String(field);
     if (!encoded_field) {
       Py_DECREF(field);
       return false;
@@ -398,7 +398,7 @@ nested_type = '__'.join(type_.namespaced_name())
     ros_message->@(member.name) = PyBytes_AS_STRING(field)[0];
 @[  elif isinstance(member.type, AbstractString)]@
     assert(PyUnicode_Check(field));
-    PyObject * encoded_field = PyUnicode_AsASCIIString(field);
+    PyObject * encoded_field = PyUnicode_AsUTF8String(field);
     if (!encoded_field) {
       Py_DECREF(field);
       return false;
@@ -632,7 +632,7 @@ nested_type = '__'.join(type_.namespaced_name())
       (void)rc;
       assert(rc == 0);
 @[    elif isinstance(member.type.value_type, AbstractString)]@
-      PyObject * decoded_item = PyUnicode_DecodeASCII(src[i].data, strlen(src[i].data), "strict");
+      PyObject * decoded_item = PyUnicode_DecodeUTF8(src[i].data, strlen(src[i].data), "strict");
       if (!decoded_item) {
         return NULL;
       }
@@ -695,7 +695,7 @@ nested_type = '__'.join(type_.namespaced_name())
       return NULL;
     }
 @[  elif isinstance(member.type, AbstractString)]@
-    field = PyUnicode_DecodeASCII(
+    field = PyUnicode_DecodeUTF8(
       ros_message->@(member.name).data,
       strlen(ros_message->@(member.name).data),
       "strict");


### PR DESCRIPTION
This patch rolls back the changes from #26 and encodes / decodes (non W-)strings as UTF-8.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7091)](http://ci.ros2.org/job/ci_linux/7091/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3317)](http://ci.ros2.org/job/ci_linux-aarch64/3317/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5813)](http://ci.ros2.org/job/ci_osx/5813/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6913)](http://ci.ros2.org/job/ci_windows/6913/)