### PR TITLE
fix PYTHONPATH for test

### DIFF
--- a/rosidl_generator_py/CMakeLists.txt
+++ b/rosidl_generator_py/CMakeLists.txt
@@ -80,9 +80,13 @@ if(BUILD_TESTING)
     if(WIN32 AND "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
       set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
     endif()
+    set(pythonpath "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py;${CMAKE_CURRENT_SOURCE_DIR}")
+    if(NOT WIN32)
+      string(REPLACE ";" ":" pythonpath "${pythonpath}")
+    endif()
     ament_add_pytest_test(test_interfaces_py "test/test_interfaces.py"
       PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}"
-      APPEND_ENV PYTHONPATH="${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py:${CMAKE_CURRENT_SOURCE_DIR}"
+      APPEND_ENV "PYTHONPATH=${pythonpath}"
       APPEND_LIBRARY_DIRS "${_append_library_dirs}"
       WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py"
     )


### PR DESCRIPTION
Fixes ros2/build_cop#209.

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7076)](https://ci.ros2.org/job/ci_windows/7076/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=7077)](https://ci.ros2.org/job/ci_windows/7077/)