### PR TITLE
Fix the setting of array variables.

### DIFF
--- a/rosidl_runtime_py/rosidl_runtime_py/set_message.py
+++ b/rosidl_runtime_py/rosidl_runtime_py/set_message.py
@@ -34,15 +34,18 @@ def set_message_fields(msg: Any, values: Dict[str, str]) -> None:
     :raises ValueError: If a message value does not match its field type.
     """
     for field_name, field_value in values.items():
-        field_type = type(getattr(msg, field_name))
+        field = getattr(msg, field_name)
+        field_type = type(field)
         try:
-            if field_type == array.array:
-                field_typecode = getattr(msg, field_name).typecode
-                value = field_type(field_typecode, field_value)
+            if field_type is array.array:
+                value = field_type(field.typecode, field_value)
             else:
                 value = field_type(field_value)
         except TypeError:
-            value = field_type()
+            if field_type is array.array:
+                value = field_type(field.typecode)
+            else:
+                value = field_type()
             set_message_fields(value, field_value)
         rosidl_type = get_message_slot_types(msg)[field_name]
         # Check if field is an array of ROS messages

--- a/rosidl_runtime_py/rosidl_runtime_py/set_message.py
+++ b/rosidl_runtime_py/rosidl_runtime_py/set_message.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import array
+
 from typing import Any
 from typing import Dict
 
@@ -34,7 +36,11 @@ def set_message_fields(msg: Any, values: Dict[str, str]) -> None:
     for field_name, field_value in values.items():
         field_type = type(getattr(msg, field_name))
         try:
-            value = field_type(field_value)
+            if field_type == array.array:
+                field_typecode = getattr(msg, field_name).typecode
+                value = field_type(field_typecode, field_value)
+            else:
+                value = field_type(field_value)
         except TypeError:
             value = field_type()
             set_message_fields(value, field_value)


### PR DESCRIPTION
If the type of the field is array.array, then a simple

  x = array.array(mylist)

doesn't work; the typecode *must* be specified.  Special-case
arrays here so that we do:

  x = array.array(typecode, list)

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix https://github.com/ros2/ros2cli/issues/270