### PR TITLE
Make the message __repr__ for python look nicer.

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -334,23 +334,19 @@ if isinstance(type_, AbstractNestedType):
         typename = self.__class__.__module__.split('.')
         typename.pop()
         typename.append(self.__class__.__name__)
-@[if 'import array' in imports]@
         args = []
-        for s in self.__slots__:
+        for s,t in zip(self.__slots__, self.SLOT_TYPES):
             field = getattr(self, s, None)
-            t = repr(field)
-            if type(field) is array.array:
+            fieldstr = repr(field)
+            if isinstance(t, rosidl_parser.definition.AbstractSequence):
                 # Calling `.tolist()` on a large array could be memory
                 # expensive, so instead we first repr() it, then strip off the
                 # "array('i')" or "array('i', [1])".
-                if t[9:11] == ', ':
-                    t = t[11:-1]
-                elif len(t) == 10:
-                    t = '[]'
-            args.append(s[1:] + '=' + t)
-@[else]@
-        args = [s[1:] + '=' + repr(getattr(self, s, None)) for s in self.__slots__]
-@[end if]@
+                if fieldstr[9:11] == ', ':
+                    fieldstr = fieldstr[11:-1]
+                elif len(fieldstr) == 10:
+                    fieldstr = '[]'
+            args.append(s[1:] + '=' + fieldstr)
         return '%s(%s)' % ('.'.join(typename), ', '.join(args))
 
     def __eq__(self, other):

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -335,7 +335,7 @@ if isinstance(type_, AbstractNestedType):
         typename.pop()
         typename.append(self.__class__.__name__)
         args = []
-        for s,t in zip(self.__slots__, self.SLOT_TYPES):
+        for s, t in zip(self.__slots__, self.SLOT_TYPES):
             field = getattr(self, s, None)
             fieldstr = repr(field)
             if isinstance(t, rosidl_parser.definition.AbstractSequence):

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -338,10 +338,15 @@ if isinstance(type_, AbstractNestedType):
         args = []
         for s in self.__slots__:
             field = getattr(self, s, None)
-            if type(field) == array.array:
-                t = repr(field.tolist())
-            else:
-                t = repr(field)
+            t = repr(field)
+            if type(field) is array.array:
+                # Calling `.tolist()` on a large array could be memory
+                # expensive, so instead we first repr() it, then strip off the
+                # "array('i')" or "array('i', [1])".
+                if t[9:11] == ', ':
+                    t = t[11:-1]
+                elif len(t) == 10:
+                    t = '[]'
             args.append(s[1:] + '=' + t)
 @[else]@
         args = [s[1:] + '=' + repr(getattr(self, s, None)) for s in self.__slots__]

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -334,7 +334,18 @@ if isinstance(type_, AbstractNestedType):
         typename = self.__class__.__module__.split('.')
         typename.pop()
         typename.append(self.__class__.__name__)
+@[if 'import array' in imports]@
+        args = []
+        for s in self.__slots__:
+            field = getattr(self, s, None)
+            if type(field) == array.array:
+                t = repr(field.tolist())
+            else:
+                t = repr(field)
+            args.append(s[1:] + '=' + t)
+@[else]@
         args = [s[1:] + '=' + repr(getattr(self, s, None)) for s in self.__slots__]
+@[end if]@
         return '%s(%s)' % ('.'.join(typename), ', '.join(args))
 
     def __eq__(self, other):

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -336,16 +336,16 @@ if isinstance(type_, AbstractNestedType):
         typename.append(self.__class__.__name__)
         args = []
         for s, t in zip(self.__slots__, self.SLOT_TYPES):
-            field = getattr(self, s, None)
+            field = getattr(self, s)
             fieldstr = repr(field)
             if isinstance(t, rosidl_parser.definition.AbstractSequence):
-                # Calling `.tolist()` on a large array could be memory
-                # expensive, so instead we first repr() it, then strip off the
-                # "array('i')" or "array('i', [1])".
-                if fieldstr[9:11] == ', ':
-                    fieldstr = fieldstr[11:-1]
-                elif len(fieldstr) == 10:
+                if len(field) == 0:
                     fieldstr = '[]'
+                else:
+                    assert fieldstr.startswith('array(')
+                    prefix = "array('X', "
+                    suffix = ')'
+                    fieldstr = fieldstr[len(prefix):-len(suffix)]
             args.append(s[1:] + '=' + fieldstr)
         return '%s(%s)' % ('.'.join(typename), ', '.join(args))
 


### PR DESCRIPTION
Before this patch, publishing a message with "ros2 topic pub"
would print something like:

publishing #5: my_msgs.msg.my_msg(axes=array('f', [0.0]))

While that is OK, it is kind of ugly.  This patch hides the
typecode and the "array" so that the output looks like:

publishing #5: my_msgs.msg.my_msg(axes=[0.0])

Which is also how it looked in Crystal.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that this is currently targeting the `fix-array-publish` branch; we'll need to retarget once that one is merged.  Also note that this is kind of an RFC; while it is quite ugly, it is a cosmetic issue, and touching the generated python code may be too risky for Dashing at this point.  I'll run CI presently, but opinions welcome.