### PR TITLE
fix logic around populating arrays

### DIFF
--- a/rosidl_runtime_py/rosidl_runtime_py/set_message.py
+++ b/rosidl_runtime_py/rosidl_runtime_py/set_message.py
@@ -36,17 +36,14 @@ def set_message_fields(msg: Any, values: Dict[str, str]) -> None:
     for field_name, field_value in values.items():
         field = getattr(msg, field_name)
         field_type = type(field)
-        try:
-            if field_type is array.array:
-                value = field_type(field.typecode, field_value)
-            else:
+        if field_type is array.array:
+            value = field_type(field.typecode, field_value)
+        else:
+            try:
                 value = field_type(field_value)
-        except TypeError:
-            if field_type is array.array:
-                value = field_type(field.typecode)
-            else:
+            except TypeError:
                 value = field_type()
-            set_message_fields(value, field_value)
+                set_message_fields(value, field_value)
         rosidl_type = get_message_slot_types(msg)[field_name]
         # Check if field is an array of ROS messages
         if isinstance(rosidl_type, AbstractNestedType):


### PR DESCRIPTION
Fixes #61 which is a consequence direct consequence of #59.

For array fields there is no need to try/except the construction. If it fails the exception should be raised as is.

This makes both examples work:

* `ros2 topic pub -r 5 /joy sensor_msgs/Joy "{header:{stamp:{sec: 0, nanosec: 0}, frame_id: 'frame'}, axes:[0.0], buttons:[0]}"`
* `ros2 topic pub -r 5 /foo std_msgs/Int32MultiArray '{layout: {dim: [{label: 'foo', size: 5, stride: 4}], data_offset: 12}, data: [1, 5.0]}'`