### PR TITLE
Ensure the contents of the field are an array.

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -339,13 +339,16 @@ if isinstance(type_, AbstractNestedType):
             field = getattr(self, s)
             fieldstr = repr(field)
             if isinstance(t, rosidl_parser.definition.AbstractSequence):
-                if len(field) == 0:
-                    fieldstr = '[]'
-                else:
-                    assert fieldstr.startswith('array(')
-                    prefix = "array('X', "
-                    suffix = ')'
-                    fieldstr = fieldstr[len(prefix):-len(suffix)]
+                # It is possible that the user assigned a non-array type to
+                # the AbstractSequence field, so only remove 'array(' if it
+                # is in the string.
+                if fieldstr.startswith('array('):
+                    if len(field) == 0:
+                        fieldstr = '[]'
+                    else:
+                        prefix = "array('X', "
+                        suffix = ')'
+                        fieldstr = fieldstr[len(prefix):-len(suffix)]
             args.append(s[1:] + '=' + fieldstr)
         return '%s(%s)' % ('.'.join(typename), ', '.join(args))
 

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -342,8 +342,8 @@ if isinstance(type_, AbstractNestedType):
             # in them, and "normal" sequences for everything else.  If it is
             # a type that we store in an array, strip off the 'array' portion.
             if (
-                isinstance(t, rosidl_parser.definition.AbstractSequence) and \
-                isinstance(t.value_type, rosidl_parser.definition.BasicType) and \
+                isinstance(t, rosidl_parser.definition.AbstractSequence) and
+                isinstance(t.value_type, rosidl_parser.definition.BasicType) and
                 t.value_type.typename in @([*SPECIAL_NESTED_BASIC_TYPES])
             ):
                 if len(field) == 0:

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -339,16 +339,15 @@ if isinstance(type_, AbstractNestedType):
             field = getattr(self, s)
             fieldstr = repr(field)
             if isinstance(t, rosidl_parser.definition.AbstractSequence):
-                # It is possible that the user assigned a non-array type to
-                # the AbstractSequence field, so only remove 'array(' if it
-                # is in the string.
-                if fieldstr.startswith('array('):
-                    if len(field) == 0:
-                        fieldstr = '[]'
-                    else:
-                        prefix = "array('X', "
-                        suffix = ')'
-                        fieldstr = fieldstr[len(prefix):-len(suffix)]
+                if len(field) == 0:
+                    fieldstr = '[]'
+                elif fieldstr.startswith('array('):
+                    # It is possible that the user assigned a non-array type to
+                    # the AbstractSequence field, so only remove 'array(' if it
+                    # is in the string.
+                    prefix = "array('X', "
+                    suffix = ')'
+                    fieldstr = fieldstr[len(prefix):-len(suffix)]
             args.append(s[1:] + '=' + fieldstr)
         return '%s(%s)' % ('.'.join(typename), ', '.join(args))
 

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -338,13 +338,16 @@ if isinstance(type_, AbstractNestedType):
         for s, t in zip(self.__slots__, self.SLOT_TYPES):
             field = getattr(self, s)
             fieldstr = repr(field)
-            if isinstance(t, rosidl_parser.definition.AbstractSequence):
+            # We use Python array type for fields that can be directly stored
+            # in them, and "normal" sequences for everything else.  If it is
+            # a type that we store in an array, strip off the 'array' portion.
+            if isinstance(t, rosidl_parser.definition.AbstractSequence) and \
+               isinstance(t.value_type, rosidl_parser.definition.BasicType) and \
+               t.value_type.typename in @([*SPECIAL_NESTED_BASIC_TYPES]):
                 if len(field) == 0:
                     fieldstr = '[]'
-                elif fieldstr.startswith('array('):
-                    # It is possible that the user assigned a non-array type to
-                    # the AbstractSequence field, so only remove 'array(' if it
-                    # is in the string.
+                else:
+                    assert fieldstr.startswith('array(')
                     prefix = "array('X', "
                     suffix = ')'
                     fieldstr = fieldstr[len(prefix):-len(suffix)]

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -341,9 +341,11 @@ if isinstance(type_, AbstractNestedType):
             # We use Python array type for fields that can be directly stored
             # in them, and "normal" sequences for everything else.  If it is
             # a type that we store in an array, strip off the 'array' portion.
-            if isinstance(t, rosidl_parser.definition.AbstractSequence) and \
-               isinstance(t.value_type, rosidl_parser.definition.BasicType) and \
-               t.value_type.typename in @([*SPECIAL_NESTED_BASIC_TYPES]):
+            if (
+                isinstance(t, rosidl_parser.definition.AbstractSequence) and \
+                isinstance(t.value_type, rosidl_parser.definition.BasicType) and \
+                t.value_type.typename in @([*SPECIAL_NESTED_BASIC_TYPES])
+            ):
                 if len(field) == 0:
                     fieldstr = '[]'
                 else:


### PR DESCRIPTION
It turns out that while all AbstractSequences are *defined*
to be arrays, we allow users to assign other sequences (like
lists) to those fields.  Make sure that the field starts with
'array(' before trying to strip it off.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix https://github.com/ros2/build_cop/issues/212