### PR TITLE
NamespacedType object has no attribute value_type

### DIFF
--- a/rosidl_runtime_py/rosidl_runtime_py/import_message.py
+++ b/rosidl_runtime_py/rosidl_runtime_py/import_message.py
@@ -20,5 +20,5 @@ from rosidl_parser.definition import NamespacedType
 
 def import_message_from_namespaced_type(message_type: NamespacedType) -> Any:
     module = importlib.import_module(
-        '.'.join(message_type.value_type.namespaces))
-    return getattr(module, message_type.value_type.name)
+        '.'.join(message_type.namespaces))
+    return getattr(module, message_type.name)


### PR DESCRIPTION
Edit:  
**WIP, test failing :s**

This PR causes the following test failure,
```terminal
=================================== FAILURES ===================================
______________________ test_set_nested_namespaced_fields _______________________
test/rosidl_runtime_py/test_set_message.py:104: in test_set_nested_namespaced_fields
    set_message_fields(unbounded_sequence_msg, test_values)
../../../../build/rosidl_runtime_py/rosidl_runtime_py/set_message.py:53: in set_message_fields
    field_elem_type = import_message_from_namespaced_type(rosidl_type)
../../../../build/rosidl_runtime_py/rosidl_runtime_py/import_message.py:23: in import_message_from_namespaced_type
    '.'.join(message_type.namespaces))
E   AttributeError: 'UnboundedSequence' object has no attribute 'namespaces'
===================== 1 failed, 17 passed in 2.16 seconds ======================
```
See #70 for more developments.

Original:
Fix #70.

Signed-off-by: artivis <jeremie.deray@canonical.com>