### PR TITLE
remove the padding member from structs which should be empty

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -18,6 +18,7 @@ from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import BOOLEAN_TYPE
 from rosidl_parser.definition import BoundedSequence
 from rosidl_parser.definition import CHARACTER_TYPES
+from rosidl_parser.definition import EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME
 from rosidl_parser.definition import FLOATING_POINT_TYPES
 from rosidl_parser.definition import INTEGER_TYPES
 from rosidl_parser.definition import NamespacedType
@@ -187,12 +188,18 @@ class @(message.structure.namespaced_type.name)(metaclass=Metaclass_@(message.st
 
     __slots__ = [
 @[for member in message.structure.members]@
+@[  if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+@[    continue]@
+@[  end if]@
         '_@(member.name)',
 @[end for]@
     ]
 
     _fields_and_field_types = {
 @[for member in message.structure.members]@
+@[  if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+@[    continue]@
+@[  end if]@
 @{
 type_ = member.type
 if isinstance(type_, AbstractNestedType):
@@ -233,6 +240,9 @@ string@
 
     SLOT_TYPES = (
 @[for member in message.structure.members]@
+@[  if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+@[    continue]@
+@[  end if]@
 @{
 type_ = member.type
 if isinstance(type_, AbstractNestedType):
@@ -269,6 +279,9 @@ if isinstance(type_, AbstractNestedType):
             'Invalid arguments passed to constructor: %s' % \
             ', '.join(sorted(k for k in kwargs.keys() if '_' + k not in self.__slots__))
 @[for member in message.structure.members]@
+@[  if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+@[    continue]@
+@[  end if]@
 @{
 type_ = member.type
 if isinstance(type_, AbstractNestedType):
@@ -374,6 +387,9 @@ if isinstance(type_, AbstractNestedType):
         from copy import copy
         return copy(cls._fields_and_field_types)
 @[for member in message.structure.members]@
+@[  if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+@[    continue]@
+@[  end if]@
 
 @{
 type_ = member.type

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -373,6 +373,9 @@ if isinstance(type_, AbstractNestedType):
         if not isinstance(other, self.__class__):
             return False
 @[for member in message.structure.members]@
+@[  if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+@[    continue]@
+@[  end if]@
 @[  if isinstance(member.type, Array) and isinstance(member.type.value_type, BasicType) and member.type.value_type.typename in SPECIAL_NESTED_BASIC_TYPES]@
         if all(self.@(member.name) != other.@(member.name)):
 @[  else]@

--- a/rosidl_generator_py/resource/_msg_support.c.em
+++ b/rosidl_generator_py/resource/_msg_support.c.em
@@ -9,6 +9,7 @@ from rosidl_parser.definition import AbstractString
 from rosidl_parser.definition import AbstractWString
 from rosidl_parser.definition import Array
 from rosidl_parser.definition import BasicType
+from rosidl_parser.definition import EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME
 from rosidl_parser.definition import NamespacedType
 
 
@@ -182,6 +183,10 @@ full_classname = '%s.%s.%s' % ('.'.join(message.structure.namespaced_type.namesp
   }
   @(msg_typename) * ros_message = _ros_message;
 @[for member in message.structure.members]@
+@[  if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+  ros_message->@(member.name) = 0;
+@[    continue]@
+@[  end if]@
 @{
 type_ = member.type
 if isinstance(type_, AbstractNestedType):
@@ -490,8 +495,15 @@ PyObject * @('__'.join(message.structure.namespaced_type.namespaces + [convert_c
       return NULL;
     }
   }
+@[if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+  (void)raw_ros_message;
+@[else]@
   @(msg_typename) * ros_message = (@(msg_typename) *)raw_ros_message;
+@[end if]@
 @[for member in message.structure.members]@
+@[  if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+@[    continue]@
+@[  end if]@
 @{
 type_ = member.type
 if isinstance(type_, AbstractNestedType):


### PR DESCRIPTION
IDL and some programming languages like C require a struct to have at least one member. Python though doesn't have that restriction and can define a class without any slots.

Therefore this patch removes the member `structure_needs_at_least_one_member` only used to "pad" empty structures from the Python data type. As a consequence printing the message won't show the member as well as the user won't see a getter and setter for the member anymore.

In the conversion from Python to C the member variable present in C is just set to `0` in order to not be uninitialized. In the other direction the value in the C struct is just ignored and not transferred to the Python object.

Fixes ros2/ros2cli#297. Requires ros2/rosidl#389.