### PR TITLE
Make import_message_from_namespaced_type operate on NamespacedType

### DIFF
--- a/rosidl_runtime_py/rosidl_runtime_py/import_message.py
+++ b/rosidl_runtime_py/rosidl_runtime_py/import_message.py
@@ -20,5 +20,5 @@ from rosidl_parser.definition import NamespacedType
 
 def import_message_from_namespaced_type(message_type: NamespacedType) -> Any:
     module = importlib.import_module(
-        '.'.join(message_type.value_type.namespaces))
-    return getattr(module, message_type.value_type.name)
+        '.'.join(message_type.namespaces))
+    return getattr(module, message_type.name)

--- a/rosidl_runtime_py/rosidl_runtime_py/import_message.py
+++ b/rosidl_runtime_py/rosidl_runtime_py/import_message.py
@@ -14,11 +14,19 @@
 
 import importlib
 from typing import Any
+import warnings
 
 from rosidl_parser.definition import NamespacedType
 
 
 def import_message_from_namespaced_type(message_type: NamespacedType) -> Any:
+    if not isinstance(message_type, NamespacedType):
+        if hasattr(message_type, 'value_type'):
+            message_type = message_type.value_type
+            warnings.warn(
+                'Passing objects containing a NamespacedType is deprecated, '
+                'please pass a NamespacedType object directly',
+                DeprecationWarning)
     module = importlib.import_module(
         '.'.join(message_type.namespaces))
     return getattr(module, message_type.name)

--- a/rosidl_runtime_py/rosidl_runtime_py/set_message.py
+++ b/rosidl_runtime_py/rosidl_runtime_py/set_message.py
@@ -50,7 +50,7 @@ def set_message_fields(msg: Any, values: Dict[str, str]) -> None:
         # Check if field is an array of ROS messages
         if isinstance(rosidl_type, AbstractNestedType):
             if isinstance(rosidl_type.value_type, NamespacedType):
-                field_elem_type = import_message_from_namespaced_type(rosidl_type)
+                field_elem_type = import_message_from_namespaced_type(rosidl_type.value_type)
                 for n in range(len(value)):
                     submsg = field_elem_type()
                     set_message_fields(submsg, value[n])

--- a/rosidl_runtime_py/test/rosidl_runtime_py/test_import_message.py
+++ b/rosidl_runtime_py/test/rosidl_runtime_py/test_import_message.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
+import warnings
 
+from rosidl_parser.definition import AbstractNestedType
 from rosidl_parser.definition import NamespacedType
 from rosidl_parser.definition import UnboundedSequence
 
@@ -26,10 +27,14 @@ def test_import_namespaced_type():
     fixture_namespaced_type = NamespacedType(['test_msgs', 'msg'], 'Empty')
     imported_message = import_message_from_namespaced_type(fixture_namespaced_type)
     assert type(imported_message) == type(Empty)
+
     not_namespaced_type = UnboundedSequence(fixture_namespaced_type)
     assert not isinstance(not_namespaced_type, NamespacedType)
-    with pytest.raises(AttributeError):
-        import_message_from_namespaced_type(not_namespaced_type)
-    imported_message2 = import_message_from_namespaced_type(
-        not_namespaced_type.value_type)
+    assert isinstance(not_namespaced_type, AbstractNestedType)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        imported_message2 = import_message_from_namespaced_type(not_namespaced_type)
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
     assert type(imported_message2) == type(Empty)

--- a/rosidl_runtime_py/test/rosidl_runtime_py/test_import_message.py
+++ b/rosidl_runtime_py/test/rosidl_runtime_py/test_import_message.py
@@ -1,0 +1,35 @@
+# Copyright 2019 Mikael Arguedas
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from rosidl_parser.definition import NamespacedType
+from rosidl_parser.definition import UnboundedSequence
+
+from rosidl_runtime_py.import_message import import_message_from_namespaced_type
+
+from test_msgs.msg import Empty
+
+
+def test_import_namespaced_type():
+    fixture_namespaced_type = NamespacedType(['test_msgs', 'msg'], 'Empty')
+    imported_message = import_message_from_namespaced_type(fixture_namespaced_type)
+    assert type(imported_message) == type(Empty)
+    not_namespaced_type = UnboundedSequence(fixture_namespaced_type)
+    assert not isinstance(not_namespaced_type, NamespacedType)
+    with pytest.raises(AttributeError):
+        import_message_from_namespaced_type(not_namespaced_type)
+    imported_message2 = import_message_from_namespaced_type(
+        not_namespaced_type.value_type)
+    assert type(imported_message2) == type(Empty)


### PR DESCRIPTION
Fixes #70 

Instead of changing the type specification, which would either require changing the function name (breaking API) or have the name and the behavior mismatch (current state), this modifies the function to operate on `NamespacedType` instead.
This will change behavior for consumers of the function.
If this is not desired, the less disruptive alternative is to change the function specification without changing the function name or the behavior.

Added a simple test to cover the uses of the function used in this package.