### PR TITLE
Remove non-package from ament_target_dependencies()

### DIFF
--- a/rosidl_generator_py/CMakeLists.txt
+++ b/rosidl_generator_py/CMakeLists.txt
@@ -49,6 +49,7 @@ if(BUILD_TESTING)
   include(cmake/register_py.cmake)
   include(cmake/rosidl_generator_py_get_typesupports.cmake)
 
+  # Trick ament_target_dependencies() into thinking this package has been found
   set(rosidl_generator_py_FOUND "1")
   set(rosidl_generator_py_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/rosidl_generator_py/CMakeLists.txt
+++ b/rosidl_generator_py/CMakeLists.txt
@@ -49,6 +49,7 @@ if(BUILD_TESTING)
   include(cmake/register_py.cmake)
   include(cmake/rosidl_generator_py_get_typesupports.cmake)
 
+  set(rosidl_generator_py_FOUND "1")
   set(rosidl_generator_py_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
   # Need to call extras before get_typesupports, to register the extension

--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -273,6 +273,8 @@ foreach(_typesupport_impl ${_typesupport_impls})
   ament_target_dependencies(${_target_name}
     "rosidl_generator_c"
     "rosidl_generator_py"
+  )
+  target_link_libraries(${_target_name}
     "${rosidl_generate_interfaces_TARGET}__rosidl_generator_c"
   )
 

--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -274,9 +274,6 @@ foreach(_typesupport_impl ${_typesupport_impls})
     "rosidl_generator_c"
     "rosidl_generator_py"
   )
-  target_link_libraries(${_target_name}
-    "${rosidl_generate_interfaces_TARGET}__rosidl_generator_c"
-  )
 
   if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
     install(TARGETS ${_target_name}


### PR DESCRIPTION
Also set _FOUND to trick `ament_target_dependencies()` call for test
interfaces

blocks ament/ament_cmake#180