### PR TITLE
Add utility functions to get interface from identifier

### DIFF
--- a/rosidl_runtime_py/rosidl_runtime_py/utilities.py
+++ b/rosidl_runtime_py/rosidl_runtime_py/utilities.py
@@ -19,26 +19,36 @@ from rosidl_parser.definition import NamespacedType
 
 def get_namespaced_type(path: Text):
     """Create a `NamespacedType` object from the full name of an interface."""
-    return __get_namespaced_type(path)
-
-
-def get_action_namespaced_type(path: Text):
-    """Create a `NamespacedType` object from the full name of an action."""
-    return __get_namespaced_type(path, 'action')
+    return _get_namespaced_type(path)
 
 
 def get_message_namespaced_type(path: Text):
     """Create a `NamespacedType` object from the full name of a message."""
-    return __get_namespaced_type(path, 'msg')
+    return _get_namespaced_type(path, 'msg')
 
 
 def get_service_namespaced_type(path: Text):
     """Create a `NamespacedType` object from the full name of a service."""
-    return __get_namespaced_type(path, 'srv')
+    return _get_namespaced_type(path, 'srv')
+
+
+def get_action_namespaced_type(path: Text):
+    """Create a `NamespacedType` object from the full name of an action."""
+    return _get_namespaced_type(path, 'action')
+
+
+def is_message(interface):
+    """Return `True` if `interface` is a message."""
+    return hasattr(interface, 'SLOT_TYPES')
+
+
+def is_service(interface):
+    """Return `True` if `interface` is a service."""
+    return hasattr(interface, 'Request') and hasattr(interface, 'Response')
 
 
 def is_action(interface):
-    """Return `True` if `action` is an action."""
+    """Return `True` if `interface` is an action."""
     return (
         hasattr(interface, 'Goal') and
         hasattr(interface, 'Result') and
@@ -46,17 +56,7 @@ def is_action(interface):
     )
 
 
-def is_service(interface):
-    """Return `True` if `srv` is a service."""
-    return hasattr(interface, 'Request') and hasattr(interface, 'Response')
-
-
-def is_message(interface):
-    """Return `True` if `msg` is a message."""
-    return hasattr(interface, 'SLOT_TYPES')
-
-
-def __get_namespaced_type(path: Text, default_namespace=None):
+def _get_namespaced_type(path: Text, default_namespace=None):
     namespace = path.split(sep='/')
     name = namespace[-1]
     namespace = namespace[0:-1]

--- a/rosidl_runtime_py/rosidl_runtime_py/utilities.py
+++ b/rosidl_runtime_py/rosidl_runtime_py/utilities.py
@@ -15,6 +15,36 @@
 from typing import Text
 
 from rosidl_parser.definition import NamespacedType
+from rosidl_runtime_py.import_message import import_message_from_namespaced_type
+
+
+def get_interface(path: Text):
+    """Get an interface from its full name."""
+    return import_message_from_namespaced_type(get_namespaced_type(path))
+
+
+def get_message(path: Text):
+    """Get a message from its full name."""
+    interface = import_message_from_namespaced_type(get_message_namespaced_type(path))
+    if not is_message(interface):
+        raise RuntimeError('Expected the full name of a message')
+    return interface
+
+
+def get_service(path: Text):
+    """Get a service from its full name."""
+    interface = import_message_from_namespaced_type(get_service_namespaced_type(path))
+    if not is_service(interface):
+        raise RuntimeError('Expected the full name of a service')
+    return interface
+
+
+def get_action(path: Text):
+    """Get a message from its full name."""
+    interface = import_message_from_namespaced_type(get_action_namespaced_type(path))
+    if not is_action(interface):
+        raise RuntimeError('Expected the full name of an action')
+    return interface
 
 
 def get_namespaced_type(path: Text):

--- a/rosidl_runtime_py/rosidl_runtime_py/utilities.py
+++ b/rosidl_runtime_py/rosidl_runtime_py/utilities.py
@@ -18,53 +18,53 @@ from rosidl_parser.definition import NamespacedType
 from rosidl_runtime_py.import_message import import_message_from_namespaced_type
 
 
-def get_interface(path: Text):
+def get_interface(identifier: Text):
     """Get an interface from its full name."""
-    return import_message_from_namespaced_type(get_namespaced_type(path))
+    return import_message_from_namespaced_type(get_namespaced_type(identifier))
 
 
-def get_message(path: Text):
+def get_message(identifier: Text):
     """Get a message from its full name."""
-    interface = import_message_from_namespaced_type(get_message_namespaced_type(path))
+    interface = import_message_from_namespaced_type(get_message_namespaced_type(identifier))
     if not is_message(interface):
-        raise RuntimeError('Expected the full name of a message')
+        raise ValueError("Expected the full name of a message, got '{}'".format(identifier))
     return interface
 
 
-def get_service(path: Text):
+def get_service(identifier: Text):
     """Get a service from its full name."""
-    interface = import_message_from_namespaced_type(get_service_namespaced_type(path))
+    interface = import_message_from_namespaced_type(get_service_namespaced_type(identifier))
     if not is_service(interface):
-        raise RuntimeError('Expected the full name of a service')
+        raise ValueError("Expected the full name of a service, got '{}'".format(identifier))
     return interface
 
 
-def get_action(path: Text):
+def get_action(identifier: Text):
     """Get a message from its full name."""
-    interface = import_message_from_namespaced_type(get_action_namespaced_type(path))
+    interface = import_message_from_namespaced_type(get_action_namespaced_type(identifier))
     if not is_action(interface):
-        raise RuntimeError('Expected the full name of an action')
+        raise ValueError("Expected the full name of an action, got '{}'".format(identifier))
     return interface
 
 
-def get_namespaced_type(path: Text):
+def get_namespaced_type(identifier: Text):
     """Create a `NamespacedType` object from the full name of an interface."""
-    return _get_namespaced_type(path)
+    return _get_namespaced_type(identifier)
 
 
-def get_message_namespaced_type(path: Text):
+def get_message_namespaced_type(identifier: Text):
     """Create a `NamespacedType` object from the full name of a message."""
-    return _get_namespaced_type(path, 'msg')
+    return _get_namespaced_type(identifier, default_namespace='msg')
 
 
-def get_service_namespaced_type(path: Text):
+def get_service_namespaced_type(identifier: Text):
     """Create a `NamespacedType` object from the full name of a service."""
-    return _get_namespaced_type(path, 'srv')
+    return _get_namespaced_type(identifier, default_namespace='srv')
 
 
-def get_action_namespaced_type(path: Text):
+def get_action_namespaced_type(identifier: Text):
     """Create a `NamespacedType` object from the full name of an action."""
-    return _get_namespaced_type(path, 'action')
+    return _get_namespaced_type(identifier, default_namespace='action')
 
 
 def is_message(interface):
@@ -86,8 +86,8 @@ def is_action(interface):
     )
 
 
-def _get_namespaced_type(path: Text, default_namespace=None):
-    namespace = path.split(sep='/')
+def _get_namespaced_type(identifier: Text, *, default_namespace=None):
+    namespace = identifier.split(sep='/')
     name = namespace[-1]
     namespace = namespace[0:-1]
     if len(namespace) == 1 and default_namespace is not None:

--- a/rosidl_runtime_py/rosidl_runtime_py/utilities.py
+++ b/rosidl_runtime_py/rosidl_runtime_py/utilities.py
@@ -17,45 +17,49 @@ from typing import Text
 from rosidl_parser.definition import NamespacedType
 
 
-def __full_type_to_namespaced_type(path: Text, default_namespace=None):
+def get_namespaced_type(path: Text):
+    """Create a `NamespacedType` object from the full name of an interface."""
+    return __get_namespaced_type(path)
+
+
+def get_action_namespaced_type(path: Text):
+    """Create a `NamespacedType` object from the full name of an action."""
+    return __get_namespaced_type(path, 'action')
+
+
+def get_message_namespaced_type(path: Text):
+    """Create a `NamespacedType` object from the full name of a message."""
+    return __get_namespaced_type(path, 'msg')
+
+
+def get_service_namespaced_type(path: Text):
+    """Create a `NamespacedType` object from the full name of a service."""
+    return __get_namespaced_type(path, 'srv')
+
+
+def is_action(interface):
+    """Return `True` if `action` is an action."""
+    return (
+        hasattr(interface, 'Goal') and
+        hasattr(interface, 'Result') and
+        hasattr(interface, 'Feedback')
+    )
+
+
+def is_service(interface):
+    """Return `True` if `srv` is a service."""
+    return hasattr(interface, 'Request') and hasattr(interface, 'Response')
+
+
+def is_message(interface):
+    """Return `True` if `msg` is a message."""
+    return hasattr(interface, 'SLOT_TYPES')
+
+
+def __get_namespaced_type(path: Text, default_namespace=None):
     namespace = path.split(sep='/')
     name = namespace[-1]
     namespace = namespace[0:-1]
     if len(namespace) == 1 and default_namespace is not None:
         namespace.append(default_namespace)
     return NamespacedType(namespace, name)
-
-
-def full_type_to_namespaced_type(path: Text):
-    """Create a `NamespacedType` object from the full name of an action."""
-    return __full_type_to_namespaced_type(path)
-
-
-def full_action_type_to_namespaced_type(path: Text):
-    """Create a `NamespacedType` object from the full name of an action."""
-    return __full_type_to_namespaced_type(path, 'action')
-
-
-def full_msg_type_to_namespaced_type(path: Text):
-    """Create a `NamespacedType` object from the full name of a message."""
-    return __full_type_to_namespaced_type(path, 'msg')
-
-
-def full_srv_type_to_namespaced_type(path: Text):
-    """Create a `NamespacedType` object from the full name of a service."""
-    return __full_type_to_namespaced_type(path, 'srv')
-
-
-def is_action(action):
-    """Return `True` if `action` is an action."""
-    return hasattr(action, 'Goal')
-
-
-def is_srv(srv):
-    """Return `True` if `srv` is a service."""
-    return hasattr(srv, 'Request')
-
-
-def is_msg(msg):
-    """Return `True` if `msg` is a message."""
-    return hasattr(msg, 'get_fields_and_field_types')

--- a/rosidl_runtime_py/rosidl_runtime_py/utilities.py
+++ b/rosidl_runtime_py/rosidl_runtime_py/utilities.py
@@ -1,0 +1,56 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Text
+
+from rosidl_parser.definition import NamespacedType
+
+
+def __full_type_to_namespaced_type(path: Text, default_namespace):
+    namespace = path.split(sep='/')
+    name = namespace[-1]
+    namespace = namespace[0:-1]
+    if len(namespace) == 1:
+        namespace.append(default_namespace)
+    return NamespacedType(namespace, name)
+
+
+def full_action_type_to_namespaced_type(path: Text):
+    """Create a `NamespacedType` object from the full name of an action."""
+    return __full_type_to_namespaced_type(path, 'action')
+
+
+def full_msg_type_to_namespaced_type(path: Text):
+    """Create a `NamespacedType` object from the full name of a message."""
+    return __full_type_to_namespaced_type(path, 'msg')
+
+
+def full_srv_type_to_namespaced_type(path: Text):
+    """Create a `NamespacedType` object from the full name of a service."""
+    return __full_type_to_namespaced_type(path, 'srv')
+
+
+def is_action(action):
+    """Return `True` if `action` is an action."""
+    return hasattr(action, 'Goal')
+
+
+def is_srv(srv):
+    """Return `True` if `srv` is a service."""
+    return hasattr(srv, 'Request')
+
+
+def is_msg(msg):
+    """Return `True` if `msg` is a message."""
+    return hasattr(msg, 'get_fields_and_field_types')

--- a/rosidl_runtime_py/rosidl_runtime_py/utilities.py
+++ b/rosidl_runtime_py/rosidl_runtime_py/utilities.py
@@ -17,13 +17,18 @@ from typing import Text
 from rosidl_parser.definition import NamespacedType
 
 
-def __full_type_to_namespaced_type(path: Text, default_namespace):
+def __full_type_to_namespaced_type(path: Text, default_namespace=None):
     namespace = path.split(sep='/')
     name = namespace[-1]
     namespace = namespace[0:-1]
-    if len(namespace) == 1:
+    if len(namespace) == 1 and default_namespace is not None:
         namespace.append(default_namespace)
     return NamespacedType(namespace, name)
+
+
+def full_type_to_namespaced_type(path: Text):
+    """Create a `NamespacedType` object from the full name of an action."""
+    return __full_type_to_namespaced_type(path)
 
 
 def full_action_type_to_namespaced_type(path: Text):

--- a/rosidl_runtime_py/test/rosidl_runtime_py/test_utilities.py
+++ b/rosidl_runtime_py/test/rosidl_runtime_py/test_utilities.py
@@ -97,21 +97,21 @@ def get_interface_functions():
     assert utilities.get_message('test_msgs/Empty') is test_msgs.msg.Empty
     assert utilities.get_service('test_msgs/Empty') is test_msgs.srv.Empty
     assert utilities.get_action('test_msgs/Fibonacci') is test_msgs.action.Fibonacci
-    with pytest.raises(RuntimeError) as ex:
+    with pytest.raises(ValueError) as ex:
         utilities.get_message('test_msgs/srv/Empty')
-    ex.matches('Expected the full name of a message')
-    with pytest.raises(RuntimeError) as ex:
+    ex.matches("Expected the full name of a message, got 'test_msgs/srv/Empty'")
+    with pytest.raises(ValueError) as ex:
         utilities.get_message('test_msgs/action/Fibonacci')
-    ex.matches('Expected the full name of a message')
-    with pytest.raises(RuntimeError) as ex:
+    ex.matches("Expected the full name of a message, got 'test_msgs/action/Fibonacci'")
+    with pytest.raises(ValueError) as ex:
         utilities.get_service('test_msgs/msg/Empty')
-    ex.matches('Expected the full name of a service')
-    with pytest.raises(RuntimeError) as ex:
+    ex.matches("Expected the full name of a service, got 'test_msgs/msg/Empty'")
+    with pytest.raises(ValueError) as ex:
         utilities.get_service('test_msgs/action/Fibonacci')
-    ex.matches('Expected the full name of a service')
-    with pytest.raises(RuntimeError) as ex:
+    ex.matches("Expected the full name of a service, got 'test_msgs/action/Fibonacci'")
+    with pytest.raises(ValueError) as ex:
         utilities.get_action('test_msgs/msg/Empty')
-    ex.matches('Expected the full name of an action')
-    with pytest.raises(RuntimeError) as ex:
+    ex.matches("Expected the full name of an action, got 'test_msgs/msg/Empty'")
+    with pytest.raises(ValueError) as ex:
         utilities.get_action('test_msgs/srv/Empty')
-    ex.matches('Expected the full name of an action')
+    ex.matches("Expected the full name of an action, got 'test_msgs/srv/Empty'")

--- a/rosidl_runtime_py/test/rosidl_runtime_py/test_utilities.py
+++ b/rosidl_runtime_py/test/rosidl_runtime_py/test_utilities.py
@@ -1,0 +1,75 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from rosidl_runtime_py import utilities
+from rosidl_runtime_py.import_message import import_message_from_namespaced_type
+
+import test_msgs.action
+import test_msgs.msg
+import test_msgs.srv
+
+
+class TestConfig:
+
+    def __init__(self, *, path, object_type, to_namespaced_type_method, is_method):
+        self.path = path
+        self.object_type = object_type
+        self.to_namespaced_type_method = to_namespaced_type_method
+        self.is_method = is_method
+
+
+@pytest.mark.parametrize('config', (
+    TestConfig(
+        path='test_msgs/msg/Empty',
+        object_type=test_msgs.msg.Empty,
+        to_namespaced_type_method=utilities.full_msg_type_to_namespaced_type,
+        is_method=utilities.is_msg
+    ),
+    TestConfig(
+        path='test_msgs/Empty',
+        object_type=test_msgs.msg.Empty,
+        to_namespaced_type_method=utilities.full_msg_type_to_namespaced_type,
+        is_method=utilities.is_msg
+    ),
+    TestConfig(
+        path='test_msgs/srv/Empty',
+        object_type=test_msgs.srv.Empty,
+        to_namespaced_type_method=utilities.full_srv_type_to_namespaced_type,
+        is_method=utilities.is_srv
+    ),
+    TestConfig(
+        path='test_msgs/Empty',
+        object_type=test_msgs.srv.Empty,
+        to_namespaced_type_method=utilities.full_srv_type_to_namespaced_type,
+        is_method=utilities.is_srv
+    ),
+    TestConfig(
+        path='test_msgs/action/Fibonacci',
+        object_type=test_msgs.action.Fibonacci,
+        to_namespaced_type_method=utilities.full_action_type_to_namespaced_type,
+        is_method=utilities.is_action
+    ),
+    TestConfig(
+        path='test_msgs/Fibonacci',
+        object_type=test_msgs.action.Fibonacci,
+        to_namespaced_type_method=utilities.full_action_type_to_namespaced_type,
+        is_method=utilities.is_action
+    ),
+))
+def test_utilities(config):
+    message = import_message_from_namespaced_type(config.to_namespaced_type_method(config.path))
+    assert message is config.object_type
+    assert config.is_method(message)

--- a/rosidl_runtime_py/test/rosidl_runtime_py/test_utilities.py
+++ b/rosidl_runtime_py/test/rosidl_runtime_py/test_utilities.py
@@ -24,55 +24,62 @@ import test_msgs.srv
 
 class TestConfig:
 
-    def __init__(self, *, path, object_type=None, to_namespaced_type_method=None, is_method=None):
+    def __init__(
+        self,
+        *,
+        path,
+        object_type=None,
+        to_namespaced_type_function=None,
+        is_function=None
+    ):
         self.path = path
         self.object_type = object_type
-        self.to_namespaced_type_method = to_namespaced_type_method
-        self.is_method = is_method
+        self.to_namespaced_type_function = to_namespaced_type_function
+        self.is_function = is_function
 
 
 @pytest.mark.parametrize('config', (
     TestConfig(
         path='test_msgs/msg/Empty',
         object_type=test_msgs.msg.Empty,
-        to_namespaced_type_method=utilities.get_message_namespaced_type,
-        is_method=utilities.is_message
+        to_namespaced_type_function=utilities.get_message_namespaced_type,
+        is_function=utilities.is_message
     ),
     TestConfig(
         path='test_msgs/Empty',
         object_type=test_msgs.msg.Empty,
-        to_namespaced_type_method=utilities.get_message_namespaced_type,
-        is_method=utilities.is_message
+        to_namespaced_type_function=utilities.get_message_namespaced_type,
+        is_function=utilities.is_message
     ),
     TestConfig(
         path='test_msgs/srv/Empty',
         object_type=test_msgs.srv.Empty,
-        to_namespaced_type_method=utilities.get_service_namespaced_type,
-        is_method=utilities.is_service
+        to_namespaced_type_function=utilities.get_service_namespaced_type,
+        is_function=utilities.is_service
     ),
     TestConfig(
         path='test_msgs/Empty',
         object_type=test_msgs.srv.Empty,
-        to_namespaced_type_method=utilities.get_service_namespaced_type,
-        is_method=utilities.is_service
+        to_namespaced_type_function=utilities.get_service_namespaced_type,
+        is_function=utilities.is_service
     ),
     TestConfig(
         path='test_msgs/action/Fibonacci',
         object_type=test_msgs.action.Fibonacci,
-        to_namespaced_type_method=utilities.get_action_namespaced_type,
-        is_method=utilities.is_action
+        to_namespaced_type_function=utilities.get_action_namespaced_type,
+        is_function=utilities.is_action
     ),
     TestConfig(
         path='test_msgs/Fibonacci',
         object_type=test_msgs.action.Fibonacci,
-        to_namespaced_type_method=utilities.get_action_namespaced_type,
-        is_method=utilities.is_action
+        to_namespaced_type_function=utilities.get_action_namespaced_type,
+        is_function=utilities.is_action
     ),
 ))
 def test_get_namespaced_type_functions(config):
-    message = import_message_from_namespaced_type(config.to_namespaced_type_method(config.path))
+    message = import_message_from_namespaced_type(config.to_namespaced_type_function(config.path))
     assert message is config.object_type
-    assert config.is_method(message)
+    assert config.is_function(message)
 
 
 def test_is_interface_functions():
@@ -87,31 +94,30 @@ def test_is_interface_functions():
     assert utilities.is_action(test_msgs.action.Fibonacci)
 
 
-def get_interface_functions():
-    assert utilities.get_interface('test_msgs/msg/Empty') is test_msgs.msg.Empty
-    assert utilities.get_interface('test_msgs/srv/Empty') is test_msgs.srv.Empty
-    assert utilities.get_interface('test_msgs/action/Fibonacci') is test_msgs.action.Fibonacci
-    assert utilities.get_message('test_msgs/msg/Empty') is test_msgs.msg.Empty
-    assert utilities.get_service('test_msgs/srv/Empty') is test_msgs.srv.Empty
-    assert utilities.get_action('test_msgs/action/Fibonacci') is test_msgs.action.Fibonacci
-    assert utilities.get_message('test_msgs/Empty') is test_msgs.msg.Empty
-    assert utilities.get_service('test_msgs/Empty') is test_msgs.srv.Empty
-    assert utilities.get_action('test_msgs/Fibonacci') is test_msgs.action.Fibonacci
+@pytest.mark.parametrize('function,identifier,result', (
+    (utilities.get_interface, 'test_msgs/msg/Empty', test_msgs.msg.Empty),
+    (utilities.get_interface, 'test_msgs/srv/Empty', test_msgs.srv.Empty),
+    (utilities.get_interface, 'test_msgs/action/Fibonacci', test_msgs.action.Fibonacci),
+    (utilities.get_message, 'test_msgs/msg/Empty', test_msgs.msg.Empty),
+    (utilities.get_message, 'test_msgs/Empty', test_msgs.msg.Empty),
+    (utilities.get_service, 'test_msgs/srv/Empty', test_msgs.srv.Empty),
+    (utilities.get_service, 'test_msgs/Empty', test_msgs.srv.Empty),
+    (utilities.get_action, 'test_msgs/action/Fibonacci', test_msgs.action.Fibonacci),
+    (utilities.get_action, 'test_msgs/Fibonacci', test_msgs.action.Fibonacci),
+))
+def test_get_interface_functions(function, identifier, result):
+    assert function(identifier) is result
+
+
+@pytest.mark.parametrize('function,identifier,interface_type', (
+    (utilities.get_message, 'test_msgs/srv/Empty', 'a message'),
+    (utilities.get_message, 'test_msgs/action/Fibonacci', 'a message'),
+    (utilities.get_service, 'test_msgs/msg/Empty', 'a service'),
+    (utilities.get_service, 'test_msgs/action/Fibonacci', 'a service'),
+    (utilities.get_action, 'test_msgs/msg/Empty', 'an action'),
+    (utilities.get_action, 'test_msgs/srv/Empty', 'an action'),
+))
+def test_get_interface_raises(function, identifier, interface_type):
     with pytest.raises(ValueError) as ex:
-        utilities.get_message('test_msgs/srv/Empty')
-    ex.matches("Expected the full name of a message, got 'test_msgs/srv/Empty'")
-    with pytest.raises(ValueError) as ex:
-        utilities.get_message('test_msgs/action/Fibonacci')
-    ex.matches("Expected the full name of a message, got 'test_msgs/action/Fibonacci'")
-    with pytest.raises(ValueError) as ex:
-        utilities.get_service('test_msgs/msg/Empty')
-    ex.matches("Expected the full name of a service, got 'test_msgs/msg/Empty'")
-    with pytest.raises(ValueError) as ex:
-        utilities.get_service('test_msgs/action/Fibonacci')
-    ex.matches("Expected the full name of a service, got 'test_msgs/action/Fibonacci'")
-    with pytest.raises(ValueError) as ex:
-        utilities.get_action('test_msgs/msg/Empty')
-    ex.matches("Expected the full name of an action, got 'test_msgs/msg/Empty'")
-    with pytest.raises(ValueError) as ex:
-        utilities.get_action('test_msgs/srv/Empty')
-    ex.matches("Expected the full name of an action, got 'test_msgs/srv/Empty'")
+        function(identifier)
+    ex.match("Expected the full name of {}, got '{}'".format(interface_type, identifier))

--- a/rosidl_runtime_py/test/rosidl_runtime_py/test_utilities.py
+++ b/rosidl_runtime_py/test/rosidl_runtime_py/test_utilities.py
@@ -35,37 +35,37 @@ class TestConfig:
     TestConfig(
         path='test_msgs/msg/Empty',
         object_type=test_msgs.msg.Empty,
-        to_namespaced_type_method=utilities.full_msg_type_to_namespaced_type,
-        is_method=utilities.is_msg
+        to_namespaced_type_method=utilities.get_message_namespaced_type,
+        is_method=utilities.is_message
     ),
     TestConfig(
         path='test_msgs/Empty',
         object_type=test_msgs.msg.Empty,
-        to_namespaced_type_method=utilities.full_msg_type_to_namespaced_type,
-        is_method=utilities.is_msg
+        to_namespaced_type_method=utilities.get_message_namespaced_type,
+        is_method=utilities.is_message
     ),
     TestConfig(
         path='test_msgs/srv/Empty',
         object_type=test_msgs.srv.Empty,
-        to_namespaced_type_method=utilities.full_srv_type_to_namespaced_type,
-        is_method=utilities.is_srv
+        to_namespaced_type_method=utilities.get_service_namespaced_type,
+        is_method=utilities.is_service
     ),
     TestConfig(
         path='test_msgs/Empty',
         object_type=test_msgs.srv.Empty,
-        to_namespaced_type_method=utilities.full_srv_type_to_namespaced_type,
-        is_method=utilities.is_srv
+        to_namespaced_type_method=utilities.get_service_namespaced_type,
+        is_method=utilities.is_service
     ),
     TestConfig(
         path='test_msgs/action/Fibonacci',
         object_type=test_msgs.action.Fibonacci,
-        to_namespaced_type_method=utilities.full_action_type_to_namespaced_type,
+        to_namespaced_type_method=utilities.get_action_namespaced_type,
         is_method=utilities.is_action
     ),
     TestConfig(
         path='test_msgs/Fibonacci',
         object_type=test_msgs.action.Fibonacci,
-        to_namespaced_type_method=utilities.full_action_type_to_namespaced_type,
+        to_namespaced_type_method=utilities.get_action_namespaced_type,
         is_method=utilities.is_action
     ),
 ))

--- a/rosidl_runtime_py/test/rosidl_runtime_py/test_utilities.py
+++ b/rosidl_runtime_py/test/rosidl_runtime_py/test_utilities.py
@@ -24,7 +24,7 @@ import test_msgs.srv
 
 class TestConfig:
 
-    def __init__(self, *, path, object_type, to_namespaced_type_method, is_method):
+    def __init__(self, *, path, object_type=None, to_namespaced_type_method=None, is_method=None):
         self.path = path
         self.object_type = object_type
         self.to_namespaced_type_method = to_namespaced_type_method
@@ -69,7 +69,49 @@ class TestConfig:
         is_method=utilities.is_action
     ),
 ))
-def test_utilities(config):
+def test_get_namespaced_type_functions(config):
     message = import_message_from_namespaced_type(config.to_namespaced_type_method(config.path))
     assert message is config.object_type
     assert config.is_method(message)
+
+
+def test_is_interface_functions():
+    assert utilities.is_message(test_msgs.msg.Empty)
+    assert not utilities.is_message(test_msgs.srv.Empty)
+    assert not utilities.is_message(test_msgs.action.Fibonacci)
+    assert not utilities.is_service(test_msgs.msg.Empty)
+    assert utilities.is_service(test_msgs.srv.Empty)
+    assert not utilities.is_service(test_msgs.action.Fibonacci)
+    assert not utilities.is_action(test_msgs.msg.Empty)
+    assert not utilities.is_action(test_msgs.srv.Empty)
+    assert utilities.is_action(test_msgs.action.Fibonacci)
+
+
+def get_interface_functions():
+    assert utilities.get_interface('test_msgs/msg/Empty') is test_msgs.msg.Empty
+    assert utilities.get_interface('test_msgs/srv/Empty') is test_msgs.srv.Empty
+    assert utilities.get_interface('test_msgs/action/Fibonacci') is test_msgs.action.Fibonacci
+    assert utilities.get_message('test_msgs/msg/Empty') is test_msgs.msg.Empty
+    assert utilities.get_service('test_msgs/srv/Empty') is test_msgs.srv.Empty
+    assert utilities.get_action('test_msgs/action/Fibonacci') is test_msgs.action.Fibonacci
+    assert utilities.get_message('test_msgs/Empty') is test_msgs.msg.Empty
+    assert utilities.get_service('test_msgs/Empty') is test_msgs.srv.Empty
+    assert utilities.get_action('test_msgs/Fibonacci') is test_msgs.action.Fibonacci
+    with pytest.raises(RuntimeError) as ex:
+        utilities.get_message('test_msgs/srv/Empty')
+    ex.matches('Expected the full name of a message')
+    with pytest.raises(RuntimeError) as ex:
+        utilities.get_message('test_msgs/action/Fibonacci')
+    ex.matches('Expected the full name of a message')
+    with pytest.raises(RuntimeError) as ex:
+        utilities.get_service('test_msgs/msg/Empty')
+    ex.matches('Expected the full name of a service')
+    with pytest.raises(RuntimeError) as ex:
+        utilities.get_service('test_msgs/action/Fibonacci')
+    ex.matches('Expected the full name of a service')
+    with pytest.raises(RuntimeError) as ex:
+        utilities.get_action('test_msgs/msg/Empty')
+    ex.matches('Expected the full name of an action')
+    with pytest.raises(RuntimeError) as ex:
+        utilities.get_action('test_msgs/srv/Empty')
+    ex.matches('Expected the full name of an action')


### PR DESCRIPTION
To avoid repeated code in some `ros2cli` packages.
See https://github.com/ros2/ros2cli/pull/301#discussion_r310283612.