### PR TITLE
[dashing backport] remove pad field from py

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -18,6 +18,7 @@ from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import BOOLEAN_TYPE
 from rosidl_parser.definition import BoundedSequence
 from rosidl_parser.definition import CHARACTER_TYPES
+from rosidl_parser.definition import EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME
 from rosidl_parser.definition import FLOATING_POINT_TYPES
 from rosidl_parser.definition import INTEGER_TYPES
 from rosidl_parser.definition import NamespacedType
@@ -187,12 +188,18 @@ class @(message.structure.namespaced_type.name)(metaclass=Metaclass_@(message.st
 
     __slots__ = [
 @[for member in message.structure.members]@
+@[  if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+@[    continue]@
+@[  end if]@
         '_@(member.name)',
 @[end for]@
     ]
 
     _fields_and_field_types = {
 @[for member in message.structure.members]@
+@[  if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+@[    continue]@
+@[  end if]@
 @{
 type_ = member.type
 if isinstance(type_, AbstractNestedType):
@@ -233,6 +240,9 @@ string@
 
     SLOT_TYPES = (
 @[for member in message.structure.members]@
+@[  if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+@[    continue]@
+@[  end if]@
 @{
 type_ = member.type
 if isinstance(type_, AbstractNestedType):
@@ -269,6 +279,9 @@ if isinstance(type_, AbstractNestedType):
             'Invalid arguments passed to constructor: %s' % \
             ', '.join(sorted(k for k in kwargs.keys() if '_' + k not in self.__slots__))
 @[for member in message.structure.members]@
+@[  if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+@[    continue]@
+@[  end if]@
 @{
 type_ = member.type
 if isinstance(type_, AbstractNestedType):
@@ -360,6 +373,9 @@ if isinstance(type_, AbstractNestedType):
         if not isinstance(other, self.__class__):
             return False
 @[for member in message.structure.members]@
+@[  if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+@[    continue]@
+@[  end if]@
 @[  if isinstance(member.type, Array) and isinstance(member.type.value_type, BasicType) and member.type.value_type.typename in SPECIAL_NESTED_BASIC_TYPES]@
         if all(self.@(member.name) != other.@(member.name)):
 @[  else]@
@@ -374,6 +390,9 @@ if isinstance(type_, AbstractNestedType):
         from copy import copy
         return copy(cls._fields_and_field_types)
 @[for member in message.structure.members]@
+@[  if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+@[    continue]@
+@[  end if]@
 
 @{
 type_ = member.type

--- a/rosidl_generator_py/resource/_msg_support.c.em
+++ b/rosidl_generator_py/resource/_msg_support.c.em
@@ -9,6 +9,7 @@ from rosidl_parser.definition import AbstractString
 from rosidl_parser.definition import AbstractWString
 from rosidl_parser.definition import Array
 from rosidl_parser.definition import BasicType
+from rosidl_parser.definition import EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME
 from rosidl_parser.definition import NamespacedType
 
 
@@ -182,6 +183,10 @@ full_classname = '%s.%s.%s' % ('.'.join(message.structure.namespaced_type.namesp
   }
   @(msg_typename) * ros_message = _ros_message;
 @[for member in message.structure.members]@
+@[  if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+  ros_message->@(member.name) = 0;
+@[    continue]@
+@[  end if]@
 @{
 type_ = member.type
 if isinstance(type_, AbstractNestedType):
@@ -490,8 +495,15 @@ PyObject * @('__'.join(message.structure.namespaced_type.namespaces + [convert_c
       return NULL;
     }
   }
+@[if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+  (void)raw_ros_message;
+@[else]@
   @(msg_typename) * ros_message = (@(msg_typename) *)raw_ros_message;
+@[end if]@
 @[for member in message.structure.members]@
+@[  if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
+@[    continue]@
+@[  end if]@
 @{
 type_ = member.type
 if isinstance(type_, AbstractNestedType):


### PR DESCRIPTION
Backport of #73. Depends on ros2/rosidl#424.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8728)](http://ci.ros2.org/job/ci_linux/8728/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4559)](http://ci.ros2.org/job/ci_linux-aarch64/4559/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7130)](http://ci.ros2.org/job/ci_osx/7130/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8643)](http://ci.ros2.org/job/ci_windows/8643/)