### PR TITLE
move 'noqa: A003' for fields named like a builtin from property to method line

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -405,13 +405,13 @@ noqa_string = ''
 if member.name in dict(inspect.getmembers(builtins)).keys():
     noqa_string = '  # noqa: A003'
 }@
-    @@property@(noqa_string)
-    def @(member.name)(self):
+    @@property
+    def @(member.name)(self):@(noqa_string)
         """Message field '@(member.name)'."""
         return self._@(member.name)
 
-    @@@(member.name).setter@(noqa_string)
-    def @(member.name)(self, value):
+    @@@(member.name).setter
+    def @(member.name)(self, value):@(noqa_string)
 @[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, BasicType) and member.type.value_type.typename in SPECIAL_NESTED_BASIC_TYPES]@
 @[    if isinstance(member.type, Array)]@
         if isinstance(value, numpy.ndarray):

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -405,12 +405,12 @@ noqa_string = ''
 if member.name in dict(inspect.getmembers(builtins)).keys():
     noqa_string = '  # noqa: A003'
 }@
-    @@property
+    @@property@(noqa_string)
     def @(member.name)(self):@(noqa_string)
         """Message field '@(member.name)'."""
         return self._@(member.name)
 
-    @@@(member.name).setter
+    @@@(member.name).setter@(noqa_string)
     def @(member.name)(self, value):@(noqa_string)
 @[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, BasicType) and member.type.value_type.typename in SPECIAL_NESTED_BASIC_TYPES]@
 @[    if isinstance(member.type, Array)]@


### PR DESCRIPTION
Moving 'noqa: A003' for fields named like a builtin from the property to the method line.

Before:
* Linux Bionic: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9688)](https://ci.ros2.org/job/ci_linux/9688/)
* Linux Focal: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9689)](https://ci.ros2.org/job/ci_linux/9689/)
* macOS: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7905)](https://ci.ros2.org/job/ci_osx/7905/)
* Windows: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9593)](https://ci.ros2.org/job/ci_windows/9593/)

After:
* Linux Bionic: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9691)](https://ci.ros2.org/job/ci_linux/9691/)
* Linux Focal: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9690)](https://ci.ros2.org/job/ci_linux/9690/)
* macOS: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7906)](https://ci.ros2.org/job/ci_osx/7906/)
* Windows: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9594)](https://ci.ros2.org/job/ci_windows/9594/)