### PR TITLE
skip inoperable typesupport implementations

### DIFF
--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -221,6 +221,11 @@ rosidl_target_interfaces(${_target_name_lib}
 
 foreach(_typesupport_impl ${_typesupport_impls})
   find_package(${_typesupport_impl} REQUIRED)
+  # a typesupport package might not be able to generated a target anymore
+  # (e.g. if an underlying vendor package isn't available in an overlay)
+  if(NOT TARGET ${rosidl_generate_interfaces_TARGET}__${_typesupport_impl})
+    continue()
+  endif()
 
   set(_pyext_suffix "__pyext")
   set(_target_name "${PROJECT_NAME}__${_typesupport_impl}${_pyext_suffix}")


### PR DESCRIPTION
Fixes #106.

Before #102 the available RMW packages where enumerated and `rmw_connext_cpp` returned `not-found` if Connext wasn't available: https://github.com/ros2/rmw_connext/blob/ae1bc361b1ee77be826b37bc3d0b2a0d6caa34ec/rmw_connext_cpp/rmw_connext_cpp-extras.cmake#L21
After #102 RMW impl. aren't considered anymore but only the type support packages.

This patch checks for the actual existence of the typesupport specific target which is about to be used instead of any secondary state (package existence, index registration, extensions, etc.). 