### PR TITLE
Force extension points to be registered in order

### DIFF
--- a/rosidl_generator_py/cmake/register_py.cmake
+++ b/rosidl_generator_py/cmake/register_py.cmake
@@ -14,6 +14,10 @@
 
 macro(rosidl_generator_py_extras BIN GENERATOR_FILES TEMPLATE_DIR)
   find_package(ament_cmake_core QUIET REQUIRED)
+  # Make sure extension points are registered in order
+  find_package(rosidl_generator_c QUIET REQUIRED)
+  find_package(rosidl_typesupport_c QUIET REQUIRED)
+
   ament_register_extension(
     "rosidl_generate_idl_interfaces"
     "rosidl_generator_py"

--- a/rosidl_generator_py/package.xml
+++ b/rosidl_generator_py/package.xml
@@ -19,6 +19,7 @@
   <buildtool_export_depend>ament_index_python</buildtool_export_depend>
   <buildtool_export_depend>python_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
+  <buildtool_export_depend>rosidl_generator_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_typesupport_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_typesupport_interface</buildtool_export_depend>
 


### PR DESCRIPTION
Similar to https://github.com/ros2/rosidl/pull/485.
Required by https://github.com/ament/ament_cmake/pull/256.