### PR TITLE
Explicitly add DLL directories for Windows before importing

### DIFF
--- a/rosidl_generator_py/package.xml
+++ b/rosidl_generator_py/package.xml
@@ -26,6 +26,7 @@
   <exec_depend>rosidl_generator_c</exec_depend>
   <exec_depend>rosidl_parser</exec_depend>
   <exec_depend>rosidl_runtime_c</exec_depend>
+  <exec_depend>rpyutils</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_index_python</test_depend>

--- a/rosidl_generator_py/rosidl_generator_py/import_type_support_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/import_type_support_impl.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import importlib
+import os
 
 
 class UnsupportedTypeSupport(Exception):
@@ -36,7 +37,19 @@ def import_type_support(pkg_name):
     :returns: the typesupport Python module for the specified package
     """
     module_name = '.{}_s__rosidl_typesupport_c'.format(pkg_name)
+    # New in Python 3.8: on Windows we should call 'add_dll_directory()' for directories
+    # containing DLLs we depend on.
+    # https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew
+    dll_dir_handles = []
+    if os.name == 'nt' and hasattr(os, 'add_dll_directory'):
+        path_env = os.environ['PATH'].split(';')
+        for prefix_path in path_env:
+            if os.path.exists(prefix_path):
+                dll_dir_handles.append(os.add_dll_directory(prefix_path))
     try:
         return importlib.import_module(module_name, package=pkg_name)
     except ImportError:
         raise UnsupportedTypeSupport(pkg_name)
+    finally:
+        for handle in dll_dir_handles:
+            handle.close()


### PR DESCRIPTION
New in Python 3.8, we should call os.add_dll_directory for directories
containing the DLLs we intend to import as well as their recursive
dependencies.

Connects to https://github.com/ros2/ci/pull/432