### PR TITLE
fix too early decref of WString when converting from Python to C

### DIFF
--- a/rosidl_generator_py/resource/_msg_support.c.em
+++ b/rosidl_generator_py/resource/_msg_support.c.em
@@ -344,14 +344,15 @@ nested_type = '__'.join(type_.namespaced_name())
       char * buffer;
       Py_ssize_t length;
       int rc = PyBytes_AsStringAndSize(encoded_item, &buffer, &length);
-      Py_DECREF(encoded_item);
       if (rc) {
+        Py_DECREF(encoded_item);
         Py_DECREF(seq_field);
         Py_DECREF(field);
         return false;
       }
       // use offset of 2 to skip BOM mark
       bool succeeded = rosidl_runtime_c__U16String__assignn_from_char(&dest[i], buffer + 2, length - 2);
+      Py_DECREF(encoded_item);
       if (!succeeded) {
         Py_DECREF(seq_field);
         Py_DECREF(field);
@@ -429,14 +430,15 @@ nested_type = '__'.join(type_.namespaced_name())
     char * buffer;
     Py_ssize_t length;
     int rc = PyBytes_AsStringAndSize(encoded_field, &buffer, &length);
-    Py_DECREF(encoded_field);
     if (rc) {
+      Py_DECREF(encoded_field);
       Py_DECREF(field);
       return false;
     }
     // use offset of 2 to skip BOM mark
     {
       bool succeeded = rosidl_runtime_c__U16String__assignn_from_char(&ros_message->@(member.name), buffer + 2, length - 2);
+      Py_DECREF(encoded_field);
       if (!succeeded) {
         Py_DECREF(field);
         return false;


### PR DESCRIPTION
Fixes #104.

Windows debug builds only testing `test_communication`:
* Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11285)](https://ci.ros2.org/job/ci_windows/11285/)
* After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11329)](https://ci.ros2.org/job/ci_windows/11329/)