### PR TITLE
Remove dependency from rosidl_typesupport_connext_c

### DIFF
--- a/rosidl_generator_py/package.xml
+++ b/rosidl_generator_py/package.xml
@@ -45,7 +45,6 @@
   <!--
   Bloom does not support group_depend so entries below duplicate the group rosidl_typesupport_c_packages.
   -->
-  <test_depend>rosidl_typesupport_connext_c</test_depend>
   <test_depend>rosidl_typesupport_introspection_c</test_depend>
   <test_depend>rosidl_typesupport_fastrtps_c</test_depend>
   <!-- end of group dependencies added for bloom -->


### PR DESCRIPTION
This PR removes a dependency from `rosidl_typesupport_connext_c`, since it will become no longer needed once `rmw_connext_cpp` is replaced by `rmw_connextdds`.

See [rticommunity/rmw_connextdds #9](https://github.com/rticommunity/rmw_connextdds/issues/9) for a list of related PRs, and an overview of all the changes required to replace [ros2/rmw_connext](https://github.com/ros2/rmw_connext) (`rmw_connext_cpp`) with [rticommunity/rmw_connextdds](https://github.com/rticommunity/rmw_connextdds) in the ROS2 source tree.