### PR TITLE
add missing float/double bounds check

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -538,6 +538,22 @@ bound = 2**nbits
 }@
             assert value >= 0 and value < @(bound), \
                 "The '@(member.name)' field must be an unsigned integer in [0, @(bound - 1)]"
+@[    elif type_.typename in FLOATING_POINT_TYPES]@
+@[      if type_.typename == "float"]@
+@{
+name = "float"
+min = 1.175494e-38
+max = 3.402823e+38
+}@
+@[      elif type_.typename == "double"]@
+@{
+name = "double"
+min = 2.2250738585072014e-308
+max = 1.7976931348623157e+308
+}@
+@[      end if]@
+            assert value >= @(min) and value <= @(max), \
+                "The '@(member.name)' field must be a @(name) in [@(min), @(max)]"
 @[    end if]@
 @[  else]@
                 False

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -497,6 +497,22 @@ bound = 2**nbits
 @[    elif isinstance(type_, BasicType) and type_.typename == 'char']@
                  all(val >= 0 and val) < 256 for val in value)), \
 @{assert_msg_suffixes.append('and each char in [0, 255]')}@
+@[    elif isinstance(type_, BasicType) and type_.typename in FLOATING_POINT_TYPES]@
+@[      if type_.typename == "float"]@
+@{
+name = "float"
+bound = 3.402823e+38
+}@
+                 all(val >= -@(bound) and val <= @(bound) for val in value)), \
+@{assert_msg_suffixes.append('and each float in [%f, %f]' % (-bound, bound))}@
+@[      elif type_.typename == "double"]@
+@{
+name = "double"
+bound = 1.7976931348623157e+308
+}@
+                 all(val >= -@(bound) and val <= @(bound) for val in value)), \
+@{assert_msg_suffixes.append('and each double in [%f, %f]' % (-bound, bound))}@
+@[      end if]@
 @[    else]@
                  True), \
 @[    end if]@

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -567,7 +567,7 @@ bound = 1.7976931348623157e+308
 }@
 @[      end if]@
             assert value >= -@(bound) and value <= @(bound), \
-                "The '@(member.name)' field must be a @(name) in [@(min), @(max)]"
+                "The '@(member.name)' field must be a @(name) in [@(-bound), @(bound)]"
 @[    end if]@
 @[  else]@
                 False

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -542,17 +542,15 @@ bound = 2**nbits
 @[      if type_.typename == "float"]@
 @{
 name = "float"
-min = 1.175494e-38
-max = 3.402823e+38
+bound = 3.402823e+38
 }@
 @[      elif type_.typename == "double"]@
 @{
 name = "double"
-min = 2.2250738585072014e-308
-max = 1.7976931348623157e+308
+bound = 1.7976931348623157e+308
 }@
 @[      end if]@
-            assert value >= @(min) and value <= @(max), \
+            assert value >= -@(bound) and value <= @(bound), \
                 "The '@(member.name)' field must be a @(name) in [@(min), @(max)]"
 @[    end if]@
 @[  else]@

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -111,6 +111,14 @@ def test_basic_types():
             setattr(msg, 'uint%d_value' % i, -1)
         with pytest.raises(AssertionError):
             setattr(msg, 'int%d_value' % i, 2**i)
+    with pytest.raises(AssertionError):
+        setattr(msg, 'float32_value', -3.5e+38)
+    with pytest.raises(AssertionError):
+        setattr(msg, 'float32_value', 3.5e+38)
+    with pytest.raises(AssertionError):
+        setattr(msg, 'float64_value', 1.8e+308)
+    with pytest.raises(AssertionError):
+        setattr(msg, 'float64_value', -1.8e+308)
 
 
 def test_strings():
@@ -450,6 +458,10 @@ def test_arrays():
         setattr(msg, 'uint64_values', [2**64, 1, 2])
     with pytest.raises(AssertionError):
         setattr(msg, 'uint64_values', [-1, 1, 2])
+    with pytest.raises(AssertionError):
+        setattr(msg, 'float32_values', [-3.5e+38, 0.0, 3.5e+38])
+    with pytest.raises(AssertionError):
+        setattr(msg, 'float64_values', [-1.8e+308, 0.0, 1.8e+308])
 
 
 def test_bounded_sequences():
@@ -661,6 +673,10 @@ def test_bounded_sequences():
         setattr(msg, 'uint64_values', [2**64, 1, 2])
     with pytest.raises(AssertionError):
         setattr(msg, 'uint64_values', [-1, 1, 2])
+    with pytest.raises(AssertionError):
+        setattr(msg, 'float32_values', [-3.5e+38, 0.0, 3.5e+38])
+    with pytest.raises(AssertionError):
+        setattr(msg, 'float64_values', [-1.8e+308, 0.0, 1.8e+308])
 
 
 def test_unbounded_sequences():
@@ -800,6 +816,10 @@ def test_unbounded_sequences():
         setattr(msg, 'uint64_values', [2**64, 1, 2])
     with pytest.raises(AssertionError):
         setattr(msg, 'uint64_values', [-1, 1, 2])
+    with pytest.raises(AssertionError):
+        setattr(msg, 'float32_values', [-3.5e+38, 0.0, 3.5e+38])
+    with pytest.raises(AssertionError):
+        setattr(msg, 'float64_values', [-1.8e+308, 0.0, 1.8e+308])
 
 
 def test_slot_attributes():


### PR DESCRIPTION
This pull request fixes the issue described below:
Floating-point types of different precision (`float32`/`float64` in ROS, `float`/`double` in rclcpp and DDS), are not handled properly in rclpy (and corresponding rosidl_python intefaces), as the type checks rely solely on Python's built-in float type.

For example, when publishing a double-sized floating point value (e.g., `3.5e+100`) as `float32` type, the data goes through various type checks at different places:
1. `if type(3.5e+100) is float` in `rosidl_runtime_py/set_message.py`,
2. `assert(isinstance(3.5e+100, float))` in the msg setter code automatically generated by rosidl,
and these checks don't reject this value as `3.5e+100` is of `float` type in Python, even though it is too big for a 32-bit float.

Then, when converting this message to a C-compatible raw message before actually publishing the data, rosidl-generated conversion code casts the value to float, where it becomes `inf`:
```
// in build/proj_name/rosidl_generator_py/proj_name/msg/_type_name_s.c
ros_message->first = (float)PyFloat_AS_DOUBLE(field);
```

As a result, the receiving end (subscriber) receives `inf`.

To fix this issue, I suggest having rosidl's generator code emit boundary checks for float/double type variables, like what's done for integer types.