### PR TITLE
Install generated Python interfaces in a Python package

### DIFF
--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -121,19 +121,7 @@ rosidl_write_generator_arguments(
 )
 
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
-  ament_python_install_module("${_output_path}/__init__.py"
-    DESTINATION_SUFFIX "${PROJECT_NAME}"
-  )
-
-  # TODO(esteve): replace this with ament_python_install_module and allow a list
-  # of modules to be passed instead of iterating over _generated_py_files
-  # See https://github.com/ros2/rosidl/issues/89
-  foreach(_generated_py_dir ${_generated_py_dirs})
-    install(DIRECTORY "${_output_path}/${_generated_py_dir}/"
-      DESTINATION "${PYTHON_INSTALL_DIR}/${PROJECT_NAME}/${_generated_py_dir}"
-      PATTERN "*.py"
-    )
-  endforeach()
+  ament_python_install_package(${PROJECT_NAME} PACKAGE_DIR "${_output_path}")
 endif()
 
 set(_target_suffix "__py")


### PR DESCRIPTION
This makes Python interfaces discoverable through `pkg_resources` and `importlib.metadata`. 


Full CI to be safe:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14692)](http://ci.ros2.org/job/ci_linux/14692/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9444)](http://ci.ros2.org/job/ci_linux-aarch64/9444/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12357)](http://ci.ros2.org/job/ci_osx/12357/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14835)](http://ci.ros2.org/job/ci_windows/14835/)
