### PR TITLE
Add smoke test for CLI extension

### DIFF
--- a/rosidl_generator_py/CMakeLists.txt
+++ b/rosidl_generator_py/CMakeLists.txt
@@ -73,6 +73,8 @@ if(BUILD_TESTING)
       WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py"
     )
   endif()
+
+  ament_add_pytest_test(test_cli_extension test/test_cli_extension.py)
 endif()
 
 ament_package(

--- a/rosidl_generator_py/test/test_cli_extension.py
+++ b/rosidl_generator_py/test/test_cli_extension.py
@@ -1,0 +1,28 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+
+from rosidl_cli.command.generate.api import generate
+
+PACKAGE_DIR = str(pathlib.Path(__file__).parent.parent)
+
+
+def test_cli_extension_for_smoke(tmp_path):
+    generate(
+        package_name='rosidl_generator_py',
+        interface_files=[PACKAGE_DIR + ':msg/StringArrays.msg'],
+        types=['py'],
+        output_path=tmp_path
+    )


### PR DESCRIPTION
Precisely what the title says. Should've added this back in #123.

CI up to `rosidl_generator_py`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14723)](http://ci.ros2.org/job/ci_linux/14723/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9475)](http://ci.ros2.org/job/ci_linux-aarch64/9475/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12390)](http://ci.ros2.org/job/ci_osx/12390/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14869)](http://ci.ros2.org/job/ci_windows/14869/)
