### PR TITLE
Support available typesupport specification in CLI extension

### DIFF
--- a/rosidl_generator_py/CMakeLists.txt
+++ b/rosidl_generator_py/CMakeLists.txt
@@ -76,11 +76,11 @@ if(BUILD_TESTING)
       APPEND_LIBRARY_DIRS "${_append_library_dirs}"
       WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py"
     )
-  endif()
 
-  ament_add_pytest_test(test_cli_extension test/test_cli_extension.py
-    PYTHON_EXECUTABLE "${BUILDTYPE_PYTHON_EXECUTABLE}"
-  )
+    ament_add_pytest_test(test_cli_extension test/test_cli_extension.py
+      PYTHON_EXECUTABLE "${BUILDTYPE_PYTHON_EXECUTABLE}"
+    )
+  endif()
 endif()
 
 ament_package(

--- a/rosidl_generator_py/rosidl_generator_py/cli.py
+++ b/rosidl_generator_py/rosidl_generator_py/cli.py
@@ -26,8 +26,8 @@ from rosidl_generator_py import generate_py
 
 class GeneratePython(GenerateCommandExtension):
 
-    def __init__(self, name, *, typesupport_implementations=None, **kwargs):
-        super().__init__(name, **kwargs)
+    def __init__(self, name, *, typesupport_implementations=None):
+        super().__init__(name)
         if typesupport_implementations is None:
             typesupport_implementations = ['rosidl_typesupport_c']
             typesupport_implementations.extend(

--- a/rosidl_generator_py/rosidl_generator_py/cli.py
+++ b/rosidl_generator_py/rosidl_generator_py/cli.py
@@ -26,6 +26,14 @@ from rosidl_generator_py import generate_py
 
 class GeneratePython(GenerateCommandExtension):
 
+    def __init__(self, name, *, typesupport_implementations=None, **kwargs):
+        super().__init__(name, **kwargs)
+        if typesupport_implementations is None:
+            typesupport_implementations = ['rosidl_typesupport_c']
+            typesupport_implementations.extend(
+                get_resources('rosidl_typesupport_c'))
+        self.__typesupport_implementations = typesupport_implementations
+
     def generate(
         self,
         package_name,
@@ -55,10 +63,6 @@ class GeneratePython(GenerateCommandExtension):
             ))
 
         # Generate code
-        typesupport_implementations = ['rosidl_typesupport_c']
-        typesupport_implementations.extend(
-            get_resources('rosidl_typesupport_c')
-        )
         with legacy_generator_arguments_file(
             package_name=package_name,
             interface_files=idl_interface_files,
@@ -68,4 +72,4 @@ class GeneratePython(GenerateCommandExtension):
         ) as path_to_arguments_file:
             return generate_py(
                 path_to_arguments_file,
-                typesupport_implementations)
+                self.__typesupport_implementations)

--- a/rosidl_generator_py/test/test_cli_extension.py
+++ b/rosidl_generator_py/test/test_cli_extension.py
@@ -23,6 +23,6 @@ def test_cli_extension_for_smoke(tmp_path):
     generate(
         package_name='rosidl_generator_py',
         interface_files=[PACKAGE_DIR + ':msg/StringArrays.msg'],
-        types=['py'],
+        types=['py[typesupport_implementations:[rosidl_typesupport_c]]'],
         output_path=tmp_path
     )

--- a/rosidl_generator_py/test/test_cli_extension.py
+++ b/rosidl_generator_py/test/test_cli_extension.py
@@ -14,15 +14,33 @@
 
 import pathlib
 
+from ament_index_python import get_resources
 from rosidl_cli.command.generate.api import generate
 
 PACKAGE_DIR = str(pathlib.Path(__file__).parent.parent)
 
 
-def test_cli_extension_for_smoke(tmp_path):
-    generate(
-        package_name='rosidl_generator_py',
-        interface_files=[PACKAGE_DIR + ':msg/StringArrays.msg'],
-        types=['py[typesupport_implementations:[rosidl_typesupport_c]]'],
-        output_path=tmp_path
-    )
+def test_cli_extension_for_smoke(tmp_path, capsys):
+    # NOTE(hidmic): pytest and empy do not play along,
+    # the latter expects some proxy will stay in sys.stdout
+    # and the former insists in overwriting it
+    interface_files = [PACKAGE_DIR + ':msg/StringArrays.msg']
+
+    with capsys.disabled():  # so do everything in one run
+        # Passing target typesupport implementations explictly
+        generate(
+            package_name='rosidl_typesupport_py',
+            interface_files=interface_files,
+            types=['py[typesupport_implementations:{}]'.format(
+                list(get_resources('rosidl_typesupport_c'))
+            )],
+            output_path=tmp_path / 'explicit_args'
+        )
+
+        # Using default typesupport implementations
+        generate(
+            package_name='rosidl_typesupport_pu',
+            interface_files=interface_files,
+            types=['py'],
+            output_path=tmp_path / 'defaults'
+        )


### PR DESCRIPTION
This patch allows the list of available typesupports to be narrowed down prior to generating Python C extensions through the `rosidl` CLI. Depends on ros2/rosidl#597. Built on top of #132.

CI up `rosidl_cli`, `rosidl_typesupport_c`, `rosidl_typesupport_cpp`, and `rosidl_generator_py`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14724)](http://ci.ros2.org/job/ci_linux/14724/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9476)](http://ci.ros2.org/job/ci_linux-aarch64/9476/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12391)](http://ci.ros2.org/job/ci_osx/12391/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14870)](http://ci.ros2.org/job/ci_windows/14870/)
