### PR TITLE
Correctly map `byte[]` AKA IDL type `sequence<octet>` to Python type `bytes`

### DIFF
--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -293,7 +293,7 @@ def test_arrays():
 
     # types
     assert isinstance(msg.bool_values, list)
-    assert isinstance(msg.byte_values, list)
+    assert isinstance(msg.byte_values, bytes)
     # for legacy reasons, 'char' from a .msg interface maps to 'uint8'
     assert isinstance(msg.char_values, numpy.ndarray)
     assert isinstance(msg.float32_values, numpy.ndarray)
@@ -329,8 +329,9 @@ def test_arrays():
     msg.bool_values = list_of_bool
     assert list_of_bool == msg.bool_values
     list_of_byte = [b'a', b'b', b'c']
-    msg.byte_values = list_of_byte
-    assert list_of_byte == msg.byte_values
+    bytes_instance = b'abc'
+    msg.byte_values = bytes_instance
+    assert bytes_instance == msg.byte_values
     list_of_char = [0, 1, 255]
     msg.char_values = list_of_char
     assert numpy.array_equal(list_of_char, msg.char_values)
@@ -369,7 +370,7 @@ def test_arrays():
     with pytest.raises(AssertionError):
         msg.bool_values = [True]
     with pytest.raises(AssertionError):
-        msg.byte_values = [b'd']
+        msg.byte_values = b'd'
     with pytest.raises(AssertionError):
         msg.char_values = [0]
     with pytest.raises(AssertionError):
@@ -397,7 +398,7 @@ def test_arrays():
     with pytest.raises(AssertionError):
         msg.bool_values = ['not', 'a', 'bool']
     with pytest.raises(AssertionError):
-        msg.byte_values = ['not', 'a', 'byte']
+        msg.byte_values = 'notabyte'
     with pytest.raises(AssertionError):
         msg.char_values = ['not', 'a', 'char']
     with pytest.raises(AssertionError):
@@ -469,7 +470,7 @@ def test_bounded_sequences():
 
     # types
     assert isinstance(msg.bool_values, list)
-    assert isinstance(msg.byte_values, list)
+    assert isinstance(msg.byte_values, bytes)
     # for legacy reasons, 'char' from a .msg interface maps to 'uint8'
     assert isinstance(msg.char_values, array.array)
     assert isinstance(msg.float32_values, array.array)
@@ -487,7 +488,7 @@ def test_bounded_sequences():
 
     # defaults
     assert [] == msg.bool_values
-    assert [] == msg.byte_values
+    assert b'' == msg.byte_values
     assert array.array('B') == msg.char_values
     assert array.array('f') == msg.float32_values
     assert array.array('d') == msg.float64_values
@@ -508,11 +509,13 @@ def test_bounded_sequences():
     msg.bool_values = short_list_of_bool
     assert short_list_of_bool == msg.bool_values
     list_of_byte = [b'a', b'b', b'c']
+    bytes_instance = b'abc'
     short_list_of_byte = [b'd']
-    msg.byte_values = list_of_byte
-    assert list_of_byte == msg.byte_values
-    msg.byte_values = short_list_of_byte
-    assert short_list_of_byte == msg.byte_values
+    short_bytes_instance = b'd'
+    msg.byte_values = bytes_instance
+    assert bytes_instance == msg.byte_values
+    msg.byte_values = short_bytes_instance
+    assert short_bytes_instance == msg.byte_values
     list_of_char = [0, 1, 255]
     short_list_of_char = [0]
     msg.char_values = list_of_char
@@ -584,7 +587,7 @@ def test_bounded_sequences():
     with pytest.raises(AssertionError):
         msg.bool_values = [True, False, True, False]
     with pytest.raises(AssertionError):
-        msg.byte_values = [b'a', b'b', b'c', b'd']
+        msg.byte_values = b'abcd'
     with pytest.raises(AssertionError):
         msg.char_values = [1, 2, 3, 4]
     with pytest.raises(AssertionError):
@@ -612,7 +615,7 @@ def test_bounded_sequences():
     with pytest.raises(AssertionError):
         msg.bool_values = ['not', 'a', 'bool']
     with pytest.raises(AssertionError):
-        msg.byte_values = ['not', 'a', 'byte']
+        msg.byte_values = 'notabyte'
     with pytest.raises(AssertionError):
         msg.char_values = ['not', 'a', 'char']
     with pytest.raises(AssertionError):
@@ -683,7 +686,7 @@ def test_unbounded_sequences():
     msg = UnboundedSequences()
 
     # types
-    assert isinstance(msg.byte_values, list)
+    assert isinstance(msg.byte_values, bytes)
     # for legacy reasons, 'char' from a .msg interface maps to 'uint8'
     assert isinstance(msg.char_values, array.array)
     assert isinstance(msg.float32_values, array.array)
@@ -701,7 +704,7 @@ def test_unbounded_sequences():
 
     # defaults
     assert [] == msg.bool_values
-    assert [] == msg.byte_values
+    assert b'' == msg.byte_values
     assert array.array('B') == msg.char_values
     assert array.array('f') == msg.float32_values
     assert array.array('d') == msg.float64_values
@@ -719,8 +722,9 @@ def test_unbounded_sequences():
     msg.bool_values = list_of_bool
     assert list_of_bool == msg.bool_values
     list_of_byte = [b'a', b'b', b'c']
-    msg.byte_values = list_of_byte
-    assert list_of_byte == msg.byte_values
+    bytes_instance = b'abc'
+    msg.byte_values = bytes_instance
+    assert bytes_instance == msg.byte_values
     list_of_char = [0, 1, 255]
     msg.char_values = list_of_char
     assert array.array('B', list_of_char) == msg.char_values
@@ -759,7 +763,7 @@ def test_unbounded_sequences():
     with pytest.raises(AssertionError):
         msg.bool_values = ['not', 'a', 'bool']
     with pytest.raises(AssertionError):
-        msg.byte_values = ['not', 'a', 'byte']
+        msg.byte_values = 'notabyte'
     with pytest.raises(AssertionError):
         msg.char_values = ['not', 'a', 'char']
     with pytest.raises(AssertionError):


### PR DESCRIPTION
As reported in #134, the message type `byte[]` AKA IDL type `sequence<octet>` is mapped to a _sequence_ of `bytes`, rather than a single `bytes` instance - which is the mapped type documented in the [design doc](http://design.ros2.org/articles/idl_interface_definition.html).

The goal of this (draft, for now) PR is to rectify that behavior.

In 14969f2, I've modified the interface tests for `Arrays`, `BoundedSequences`, and `UnboundedSequences` to reflect the correct mapping from IDL type `sequence<octet>` to Python type `bytes`, rather than Python type `list`. As expected, these changes will cause test failures in the [build job](https://build.ros2.org/job/Rpr__rosidl_python__ubuntu_focal_amd64/50/).

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>