### PR TITLE
fix for msg file containing a property field that is not at the end

### DIFF
--- a/rosidl_generator_py/CMakeLists.txt
+++ b/rosidl_generator_py/CMakeLists.txt
@@ -57,6 +57,7 @@ if(BUILD_TESTING)
       ${test_interface_files_MSG_FILES}
       # Cases not covered by test_interface_files
       msg/StringArrays.msg
+      msg/Property.msg
       ADD_LINTER_TESTS
       SKIP_INSTALL
     )
@@ -79,6 +80,13 @@ if(BUILD_TESTING)
 
     ament_add_pytest_test(test_cli_extension test/test_cli_extension.py
       PYTHON_EXECUTABLE "${BUILDTYPE_PYTHON_EXECUTABLE}"
+    )
+
+    ament_add_pytest_test(test_property_py test/test_property.py
+      PYTHON_EXECUTABLE "${BUILDTYPE_PYTHON_EXECUTABLE}"
+      APPEND_ENV "PYTHONPATH=${pythonpath}"
+      APPEND_LIBRARY_DIRS "${_append_library_dirs}"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_py"
     )
   endif()
 endif()

--- a/rosidl_generator_py/msg/Property.msg
+++ b/rosidl_generator_py/msg/Property.msg
@@ -1,0 +1,2 @@
+string property
+string anything

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -36,6 +36,9 @@ if message.structure.members:
     imports.setdefault(
         'import rosidl_parser.definition', [])  # used for SLOT_TYPES
 for member in message.structure.members:
+    if member.name != EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME:
+        imports.setdefault(
+            'import builtins', [])  # used for @builtins.property
     if (
         isinstance(member.type, AbstractNestedType) and
         isinstance(member.type.value_type, BasicType) and
@@ -405,7 +408,7 @@ noqa_string = ''
 if member.name in dict(inspect.getmembers(builtins)).keys():
     noqa_string = '  # noqa: A003'
 }@
-    @@property@(noqa_string)
+    @@builtins.property@(noqa_string)
     def @(member.name)(self):@(noqa_string)
         """Message field '@(member.name)'."""
         return self._@(member.name)

--- a/rosidl_generator_py/test/test_property.py
+++ b/rosidl_generator_py/test/test_property.py
@@ -1,0 +1,35 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rosidl_generator_py.msg import Property
+
+
+def test_msg_property():
+    msg = Property()
+
+    # types
+    assert isinstance(msg.property, str)
+    assert isinstance(msg.anything, str)
+
+    # default values
+    assert '' == msg.property
+    assert '' == msg.anything
+
+    # set values
+    msg.property = 'a_value'
+    msg.anything = 'another_value'
+
+    # get values
+    assert 'a_value' == msg.property
+    assert 'another_value' == msg.anything


### PR DESCRIPTION
The `@property`(s) of the constant(UPPER_CASE) and default({NAME}__DEFAULT) in the `Metaclass_Property` do not need to be updated.

to fix https://github.com/ros2/rosidl_python/issues/150

Signed-off-by: Chen Lihui <lihui.chen@sony.com>