### PR TITLE
Don't export the generated libraries as targets anymore

### DIFF
--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -273,14 +273,9 @@ if(WIN32)
 endif()
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   install(TARGETS ${_target_name_lib}
-    EXPORT export_${_target_name_lib}
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin)
-
-  # Export this target so downstream interface packages can depend on it
-  rosidl_export_typesupport_targets("${rosidl_generator_py_suffix}" "${_target_name_lib}")
-  ament_export_targets(export_${_target_name_lib})
 endif()
 
 if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)


### PR DESCRIPTION
Nothing should depend on them (they are meant only to be loaded as python extensions).

Issue was introduced in https://github.com/ros2/rosidl_python/pull/160.

This was causing build issues in rhel https://ci.ros2.org/view/nightly/job/nightly_linux-rhel_release/1139/console#console-section-12.
It didn't cause issues in other platforms as they realize the library they're linking agains isn't being used for anything, so they don't look at the missing symbols.
But rhel linker seems to be more picky.