### PR TITLE
:man_farmer: Fix NaN values bound numpy windows version

### DIFF
--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -505,12 +505,12 @@ def test_arrays():
     # NaN
     arr_of_float32_with_nan = numpy.array([-1.33, math.nan, 1.33], dtype=numpy.float32)
     setattr(msg, 'float32_values', arr_of_float32_with_nan)
-    assert ((arr_of_float32_with_nan==msg.float32_values)|
-            (numpy.isnan(arr_of_float32_with_nan)&numpy.isnan(msg.float32_values))).all()
+    assert numpy.asarray(arr_of_float32_with_nan[~numpy.isnan(arr_of_float32_with_nan)] == 
+            msg.float32_values[~numpy.isnan(arr_of_float32_with_nan)]).all()
     arr_of_float64_with_nan = numpy.array([-1.66, math.nan, 1.66], dtype=numpy.float64)
     setattr(msg, 'float64_values', arr_of_float64_with_nan)
-    assert ((arr_of_float64_with_nan==msg.float32_values)|
-            (numpy.isnan(arr_of_float64_with_nan)&numpy.isnan(msg.float64_values))).all()
+    assert numpy.asarray(arr_of_float64_with_nan[~numpy.isnan(arr_of_float64_with_nan)] == 
+            msg.float64_values[~numpy.isnan(arr_of_float64_with_nan)]).all()
     # Inf
     arr_of_float32_with_inf = numpy.array([-math.inf, 5.5, math.inf], dtype=numpy.float32)
     setattr(msg, 'float32_values', arr_of_float32_with_inf)

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -505,11 +505,12 @@ def test_arrays():
     # NaN
     arr_of_float32_with_nan = numpy.array([-1.33, math.nan, 1.33], dtype=numpy.float32)
     setattr(msg, 'float32_values', arr_of_float32_with_nan)
-    assert bool(numpy.asarray(arr_of_float32_with_nan[~numpy.isnan(arr_of_float32_with_nan)] == msg.float32_values[~numpy.isnan(arr_of_float32_with_nan)]).all())
+    assert ((arr_of_float32_with_nan==msg.float32_values)|
+            (numpy.isnan(arr_of_float32_with_nan)&numpy.isnan(msg.float32_values))).all()
     arr_of_float64_with_nan = numpy.array([-1.66, math.nan, 1.66], dtype=numpy.float64)
     setattr(msg, 'float64_values', arr_of_float64_with_nan)
-    assert bool(numpy.asarray(arr_of_float64_with_nan[~numpy.isnan(arr_of_float64_with_nan)] == msg.float64_values[~numpy.isnan(arr_of_float64_with_nan)]).all())
-
+    assert ((arr_of_float64_with_nan==msg.float32_values)|
+            (numpy.isnan(arr_of_float64_with_nan)&numpy.isnan(msg.float64_values))).all()
     # Inf
     arr_of_float32_with_inf = numpy.array([-math.inf, 5.5, math.inf], dtype=numpy.float32)
     setattr(msg, 'float32_values', arr_of_float32_with_inf)

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -505,10 +505,10 @@ def test_arrays():
     # NaN
     arr_of_float32_with_nan = numpy.array([-1.33, math.nan, 1.33], dtype=numpy.float32)
     setattr(msg, 'float32_values', arr_of_float32_with_nan)
-    assert numpy.array_equal(arr_of_float32_with_nan, msg.float32_values, equal_nan=True)
+    assert bool(numpy.asarray(arr_of_float32_with_nan[~numpy.isnan(arr_of_float32_with_nan)] == msg.float32_values[~numpy.isnan(arr_of_float32_with_nan)]).all())
     arr_of_float64_with_nan = numpy.array([-1.66, math.nan, 1.66], dtype=numpy.float64)
     setattr(msg, 'float64_values', arr_of_float64_with_nan)
-    assert numpy.array_equal(arr_of_float64_with_nan, msg.float64_values, equal_nan=True)
+    assert bool(numpy.asarray(arr_of_float64_with_nan[~numpy.isnan(arr_of_float64_with_nan)] == msg.float64_values[~numpy.isnan(arr_of_float64_with_nan)]).all())
 
     # Inf
     arr_of_float32_with_inf = numpy.array([-math.inf, 5.5, math.inf], dtype=numpy.float32)

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -505,12 +505,16 @@ def test_arrays():
     # NaN
     arr_of_float32_with_nan = numpy.array([-1.33, math.nan, 1.33], dtype=numpy.float32)
     setattr(msg, 'float32_values', arr_of_float32_with_nan)
-    assert numpy.asarray(arr_of_float32_with_nan[~numpy.isnan(arr_of_float32_with_nan)] == 
-            msg.float32_values[~numpy.isnan(arr_of_float32_with_nan)]).all()
+    arr_with_nan = numpy.isnan(arr_of_float32_with_nan)
+    assert numpy.shape(arr_of_float32_with_nan) == numpy.shape(msg.float32_values) and (
+            numpy.asarray(arr_of_float32_with_nan[~arr_with_nan] == 
+                msg.float32_values[~arr_with_nan]).all())
     arr_of_float64_with_nan = numpy.array([-1.66, math.nan, 1.66], dtype=numpy.float64)
     setattr(msg, 'float64_values', arr_of_float64_with_nan)
-    assert numpy.asarray(arr_of_float64_with_nan[~numpy.isnan(arr_of_float64_with_nan)] == 
-            msg.float64_values[~numpy.isnan(arr_of_float64_with_nan)]).all()
+    arr_with_nan = numpy.isnan(arr_of_float64_with_nan)
+    assert numpy.shape(arr_of_float64_with_nan) == numpy.shape(msg.float64_values) and (
+            numpy.asarray(arr_of_float64_with_nan[~arr_with_nan] == 
+                msg.float64_values[~arr_with_nan]).all())
     # Inf
     arr_of_float32_with_inf = numpy.array([-math.inf, 5.5, math.inf], dtype=numpy.float32)
     setattr(msg, 'float32_values', arr_of_float32_with_inf)

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -507,14 +507,14 @@ def test_arrays():
     setattr(msg, 'float32_values', arr_of_float32_with_nan)
     arr_with_nan = numpy.isnan(arr_of_float32_with_nan)
     assert numpy.shape(arr_of_float32_with_nan) == numpy.shape(msg.float32_values) and (
-            numpy.asarray(arr_of_float32_with_nan[~arr_with_nan] == 
-                msg.float32_values[~arr_with_nan]).all())
+        numpy.asarray(arr_of_float32_with_nan[~arr_with_nan] ==
+                      msg.float32_values[~arr_with_nan]).all())
     arr_of_float64_with_nan = numpy.array([-1.66, math.nan, 1.66], dtype=numpy.float64)
     setattr(msg, 'float64_values', arr_of_float64_with_nan)
     arr_with_nan = numpy.isnan(arr_of_float64_with_nan)
     assert numpy.shape(arr_of_float64_with_nan) == numpy.shape(msg.float64_values) and (
-            numpy.asarray(arr_of_float64_with_nan[~arr_with_nan] == 
-                msg.float64_values[~arr_with_nan]).all())
+        numpy.asarray(arr_of_float64_with_nan[~arr_with_nan] ==
+                      msg.float64_values[~arr_with_nan]).all())
     # Inf
     arr_of_float32_with_inf = numpy.array([-math.inf, 5.5, math.inf], dtype=numpy.float32)
     setattr(msg, 'float32_values', arr_of_float32_with_inf)


### PR DESCRIPTION
### :fly: BugFix

#### Issue

* The error is related to an unexpected keyword argument 'equal_nan' (Failing test [in rosidl PR](https://github.com/ros2/rosidl_python/pull/167/files#diff-f4b8ecb2aff8d495234eaf98c514cc3c04a8575d96aa46f29c5a137d894ff7c3R508)).
* We noticed this is a feature from numpy >= 1.19.0 (See https://github.com/numpy/numpy/pull/16128).
* Also, Windows Debug job has pinned numpy version to 1.18.4 [here](https://github.com/ros2/ci/blob/dabb6fd0f8357f727b7e73fbb41d07748bee6ad7/ros2_batch_job/__main__.py#L567).

Reference build: [Nightly Windows Debug](https://ci.ros2.org/view/nightly/job/nightly_win_deb/2458/testReport/junit/rosidl_generator_py.test/test_interfaces/test_arrays/)

Log output:
```
>       assert numpy.array_equal(arr_of_float32_with_nan, msg.float32_values, equal_nan=True)

C:\ci\ws\src\ros2\rosidl_python\rosidl_generator_py\test\test_interfaces.py:508: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

args = (array([-1.33,   nan,  1.33], dtype=float32), array([-1.33,   nan,  1.33], dtype=float32))
kwargs = {'equal_nan': True}

>   ???
E   TypeError: _array_equal_dispatcher() got an unexpected keyword argument 'equal_nan'

<__array_function__ internals>:4: TypeError
```

#### Investigation


The proposed solution changes this test behavior to support both numpy <= 1.18 and >= 1.19.

Selected implementation: https://github.com/rossbar/numpy/blob/main/numpy/core/numeric.py#L2475
```python
asarray(a1[~a1nan] == a2[~a1nan]).all() # plus shape verification
```
Windows build: [![Build Status](https://ci.ros2.org/job/ci_windows/17637/badge/icon)](https://ci.ros2.org/job/ci_windows/17637/)
Linux aarch64 build:[![Build Status](https://ci.ros2.org/job/ci_linux-aarch64/11752/badge/icon)](https://ci.ros2.org/job/ci_linux-aarch64/11752/)
Linux build: [![Build Status](https://ci.ros2.org/job/ci_linux/17209/badge/icon)](https://ci.ros2.org/job/ci_linux/17209/)