### PR TITLE
Remove stray numpy import

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -30,7 +30,6 @@ from rosidl_parser.definition import UNSIGNED_INTEGER_TYPES
 @# Collect necessary import statements for all members
 @{
 from collections import OrderedDict
-import numpy
 imports = OrderedDict()
 if message.structure.members:
     imports.setdefault(


### PR DESCRIPTION
NumPy was being imported in the template code (not the template output) for no obvious reason. This was causing problems when cross-compiling, where NumPy may be only available for the target platform.