### PR TITLE
use ament_python_install_package when package is not installed

### DIFF
--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -122,10 +122,6 @@ rosidl_write_generator_arguments(
 
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   if(${PROJECT_NAME} IN_LIST AMENT_CMAKE_PYTHON_INSTALL_INSTALLED_NAMES)
-    ament_python_install_module("${_output_path}/__init__.py"
-      DESTINATION_SUFFIX "${PROJECT_NAME}"
-    )
-
     # TODO(esteve): replace this with ament_python_install_module and allow a list
     # of modules to be passed instead of iterating over _generated_py_files
     # See https://github.com/ros2/rosidl/issues/89


### PR DESCRIPTION
this PR fix #141 
with this PR, we can use `rosidl_generator_interfaces` and `ament_python_install_package` in the same CMakeLists.txt.

**But the order is important.**
as https://github.com/ros-drivers/audio_common/pull/212, we need to `ament_python_install_package` first and `rosidl_generate_interfaces` later.

```cmake
ament_python_install_package(${PROJECT_NAME})

rosidl_generate_interfaces(${PROJECT_NAME}
  ${msg_files}
  ${action_files}
  DEPENDENCIES
    action_msgs
    audio_common_msgs
    builtin_interfaces
)
```