### PR TITLE
Backport NaN fixes

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -30,7 +30,6 @@ from rosidl_parser.definition import UNSIGNED_INTEGER_TYPES
 @# Collect necessary import statements for all members
 @{
 from collections import OrderedDict
-import numpy
 imports = OrderedDict()
 if message.structure.members:
     imports.setdefault(

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -36,9 +36,15 @@ if message.structure.members:
     imports.setdefault(
         'import rosidl_parser.definition', [])  # used for SLOT_TYPES
 for member in message.structure.members:
+    type_ = member.type
+    if isinstance(type_, AbstractNestedType):
+        type_ = type_.value_type
     if member.name != EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME:
         imports.setdefault(
             'import builtins', [])  # used for @builtins.property
+    if isinstance(type_, BasicType) and type_.typename in FLOATING_POINT_TYPES:
+        imports.setdefault(
+            'import math', [])  # used for math.isinf
     if (
         isinstance(member.type, AbstractNestedType) and
         isinstance(member.type.value_type, BasicType) and
@@ -504,16 +510,16 @@ bound = 2**nbits
 @[      if type_.typename == "float"]@
 @{
 name = "float"
-bound = 3.402823e+38
+bound = 3.402823466e+38
 }@
-                 all(val >= -@(bound) and val <= @(bound) for val in value)), \
+                 all(not (val < -@(bound) or val > @(bound)) or math.isinf(val) for val in value)), \
 @{assert_msg_suffixes.append('and each float in [%f, %f]' % (-bound, bound))}@
 @[      elif type_.typename == "double"]@
 @{
 name = "double"
 bound = 1.7976931348623157e+308
 }@
-                 all(val >= -@(bound) and val <= @(bound) for val in value)), \
+                 all(not (val < -@(bound) or val > @(bound)) or math.isinf(val) for val in value)), \
 @{assert_msg_suffixes.append('and each double in [%f, %f]' % (-bound, bound))}@
 @[      end if]@
 @[    else]@
@@ -561,7 +567,7 @@ bound = 2**nbits
 @[      if type_.typename == "float"]@
 @{
 name = "float"
-bound = 3.402823e+38
+bound = 3.402823466e+38
 }@
 @[      elif type_.typename == "double"]@
 @{
@@ -569,7 +575,7 @@ name = "double"
 bound = 1.7976931348623157e+308
 }@
 @[      end if]@
-            assert value >= -@(bound) and value <= @(bound), \
+            assert not (value < -@(bound) or value > @(bound)) or math.isinf(value), \
                 "The '@(member.name)' field must be a @(name) in [@(-bound), @(bound)]"
 @[    end if]@
 @[  else]@

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import array
+import math
+import sys
 
 import numpy
 import pytest
@@ -112,14 +114,38 @@ def test_basic_types():
             setattr(msg, 'uint%d_value' % i, -1)
         with pytest.raises(AssertionError):
             setattr(msg, 'int%d_value' % i, 2**i)
+    float32_ieee_max_next = numpy.nextafter(3.402823466e+38, math.inf)
     with pytest.raises(AssertionError):
-        setattr(msg, 'float32_value', -3.5e+38)
+        setattr(msg, 'float32_value', -float32_ieee_max_next)
     with pytest.raises(AssertionError):
-        setattr(msg, 'float32_value', 3.5e+38)
-    with pytest.raises(AssertionError):
-        setattr(msg, 'float64_value', 1.8e+308)
-    with pytest.raises(AssertionError):
-        setattr(msg, 'float64_value', -1.8e+308)
+        setattr(msg, 'float32_value', float32_ieee_max_next)
+
+    # Only run bounds test on system with non-compliant IEEE 754 float64.
+    # Otherwise the number is implicitly converted to inf.
+    if sys.float_info.max > 1.7976931348623157e+308:
+        float64_ieee_max_next = numpy.nextafter(1.7976931348623157e+308, math.inf)
+        with pytest.raises(AssertionError):
+            setattr(msg, 'float64_value', -float64_ieee_max_next)
+        with pytest.raises(AssertionError):
+            setattr(msg, 'float64_value', float64_ieee_max_next)
+
+    # NaN
+    setattr(msg, 'float32_value', math.nan)
+    assert math.isnan(msg.float32_value)
+    setattr(msg, 'float64_value', math.nan)
+    assert math.isnan(msg.float64_value)
+
+    # -Inf
+    setattr(msg, 'float32_value', -math.inf)
+    assert math.isinf(msg.float32_value)
+    setattr(msg, 'float64_value', -math.inf)
+    assert math.isinf(msg.float64_value)
+
+    # +Inf
+    setattr(msg, 'float32_value', math.inf)
+    assert math.isinf(msg.float32_value)
+    setattr(msg, 'float64_value', math.inf)
+    assert math.isinf(msg.float64_value)
 
 
 def test_strings():
@@ -460,9 +486,37 @@ def test_arrays():
     with pytest.raises(AssertionError):
         setattr(msg, 'uint64_values', [-1, 1, 2])
     with pytest.raises(AssertionError):
-        setattr(msg, 'float32_values', [-3.5e+38, 0.0, 3.5e+38])
+        float32_ieee_max_next = numpy.nextafter(3.402823466e+38, math.inf)
+        setattr(msg, 'float32_values', [-float32_ieee_max_next, 0.0])
     with pytest.raises(AssertionError):
-        setattr(msg, 'float64_values', [-1.8e+308, 0.0, 1.8e+308])
+        float32_ieee_max_next = numpy.nextafter(3.402823466e+38, math.inf)
+        setattr(msg, 'float32_values', [0.0, float32_ieee_max_next])
+
+    # If target system is IEEE 754 compliant, the next number is rounded to inf.
+    # Only perform this check on non-compliant systems.
+    if sys.float_info.max > 1.7976931348623157e+308:
+        with pytest.raises(AssertionError):
+            float64_ieee_max_next = numpy.nextafter(1.7976931348623157e+308, math.inf)
+            setattr(msg, 'float64_values', [-float64_ieee_max_next, 0.0])
+        with pytest.raises(AssertionError):
+            float64_ieee_max_next = numpy.nextafter(1.7976931348623157e+308, math.inf)
+            setattr(msg, 'float64_values', [-float64_ieee_max_next, 0.0])
+
+    # NaN
+    arr_of_float32_with_nan = numpy.array([-1.33, math.nan, 1.33], dtype=numpy.float32)
+    setattr(msg, 'float32_values', arr_of_float32_with_nan)
+    assert numpy.array_equal(arr_of_float32_with_nan, msg.float32_values, equal_nan=True)
+    arr_of_float64_with_nan = numpy.array([-1.66, math.nan, 1.66], dtype=numpy.float64)
+    setattr(msg, 'float64_values', arr_of_float64_with_nan)
+    assert numpy.array_equal(arr_of_float64_with_nan, msg.float64_values, equal_nan=True)
+
+    # Inf
+    arr_of_float32_with_inf = numpy.array([-math.inf, 5.5, math.inf], dtype=numpy.float32)
+    setattr(msg, 'float32_values', arr_of_float32_with_inf)
+    assert numpy.array_equal(arr_of_float32_with_inf, msg.float32_values)
+    arr_of_float64_with_inf = numpy.array([-math.inf, 5.5, math.inf], dtype=numpy.float64)
+    setattr(msg, 'float64_values', arr_of_float64_with_inf)
+    assert numpy.array_equal(arr_of_float64_with_inf, msg.float64_values)
 
 
 def test_bounded_sequences():
@@ -675,9 +729,18 @@ def test_bounded_sequences():
     with pytest.raises(AssertionError):
         setattr(msg, 'uint64_values', [-1, 1, 2])
     with pytest.raises(AssertionError):
-        setattr(msg, 'float32_values', [-3.5e+38, 0.0, 3.5e+38])
+        float32_ieee_max_next = numpy.nextafter(3.402823466e+38, math.inf)
+        setattr(msg, 'float32_values', [-float32_ieee_max_next, 0.0])
     with pytest.raises(AssertionError):
-        setattr(msg, 'float64_values', [-1.8e+308, 0.0, 1.8e+308])
+        float32_ieee_max_next = numpy.nextafter(3.402823466e+38, math.inf)
+        setattr(msg, 'float32_values', [0.0, float32_ieee_max_next])
+
+    # If target system is IEEE 754 compliant, the next number is rounded to inf.
+    # Only perform this check on non-compliant systems.
+    if sys.float_info.max > 1.7976931348623157e+308:
+        with pytest.raises(AssertionError):
+            float64_ieee_max_next = numpy.nextafter(1.7976931348623157e+308, math.inf)
+            setattr(msg, 'float64_values', [-float64_ieee_max_next, 0.0, float64_ieee_max_next])
 
 
 def test_unbounded_sequences():
@@ -818,9 +881,15 @@ def test_unbounded_sequences():
     with pytest.raises(AssertionError):
         setattr(msg, 'uint64_values', [-1, 1, 2])
     with pytest.raises(AssertionError):
-        setattr(msg, 'float32_values', [-3.5e+38, 0.0, 3.5e+38])
-    with pytest.raises(AssertionError):
-        setattr(msg, 'float64_values', [-1.8e+308, 0.0, 1.8e+308])
+        float32_ieee_max_next = numpy.nextafter(3.402823466e+38, math.inf)
+        setattr(msg, 'float32_values', [-float32_ieee_max_next, 0.0, float32_ieee_max_next])
+
+    # If target system is IEEE 754 compliant, the next number is rounded to inf.
+    # Only perform this check on non-compliant systems.
+    if sys.float_info.max > 1.7976931348623157e+308:
+        with pytest.raises(AssertionError):
+            float64_ieee_max_next = numpy.nextafter(1.7976931348623157e+308, math.inf)
+            setattr(msg, 'float64_values', [-float64_ieee_max_next, 0.0, float64_ieee_max_next])
 
 
 def test_slot_attributes():

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -505,11 +505,16 @@ def test_arrays():
     # NaN
     arr_of_float32_with_nan = numpy.array([-1.33, math.nan, 1.33], dtype=numpy.float32)
     setattr(msg, 'float32_values', arr_of_float32_with_nan)
-    assert numpy.array_equal(arr_of_float32_with_nan, msg.float32_values, equal_nan=True)
+    arr_with_nan = numpy.isnan(arr_of_float32_with_nan)
+    assert numpy.shape(arr_of_float32_with_nan) == numpy.shape(msg.float32_values) and (
+        numpy.asarray(arr_of_float32_with_nan[~arr_with_nan] ==
+                      msg.float32_values[~arr_with_nan]).all())
     arr_of_float64_with_nan = numpy.array([-1.66, math.nan, 1.66], dtype=numpy.float64)
     setattr(msg, 'float64_values', arr_of_float64_with_nan)
-    assert numpy.array_equal(arr_of_float64_with_nan, msg.float64_values, equal_nan=True)
-
+    arr_with_nan = numpy.isnan(arr_of_float64_with_nan)
+    assert numpy.shape(arr_of_float64_with_nan) == numpy.shape(msg.float64_values) and (
+        numpy.asarray(arr_of_float64_with_nan[~arr_with_nan] ==
+                      msg.float64_values[~arr_with_nan]).all())
     # Inf
     arr_of_float32_with_inf = numpy.array([-math.inf, 5.5, math.inf], dtype=numpy.float32)
     setattr(msg, 'float32_values', arr_of_float32_with_inf)


### PR DESCRIPTION
This PR backports https://github.com/ros2/rosidl_python/pull/167, https://github.com/ros2/rosidl_python/pull/182, and https://github.com/ros2/rosidl_python/pull/185 .  The combination of those PRs allows NaN to be successfully decoded in Python code, which fixes a number of issues that users have reported, including https://github.com/ros2/ros2/issues/1341.

Tested locally to at least fix that latter issue.

@sloretz @fujitatomoya I'd appreciate review from both of you.