### PR TITLE
Hides the assertions that checks the data types of the message fields.

### DIFF
--- a/rosidl_generator_py/resource/_idl.py.em
+++ b/rosidl_generator_py/resource/_idl.py.em
@@ -1,6 +1,13 @@
 # generated from rosidl_generator_py/resource/_idl.py.em
 # with input from @(package_name):@(interface_path)
 # generated code does not contain a copyright notice
+
+# This is being done at the module level and not on the instance level to avoid looking
+# for the same variable multiple times on each instance. This variable is not supposed to
+# change during runtime so it makes sense to only look for it once.
+from os import getenv
+
+ros_python_check_fields = getenv('ROS_PYTHON_CHECK_FIELDS', default='')
 @
 @#######################################################################
 @# EmPy template for generating _<idl>.py files

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -372,7 +372,7 @@ if isinstance(type_, AbstractNestedType):
         typename.pop()
         typename.append(self.__class__.__name__)
         args = []
-        for s, t in zip(self.get_fields_and_field_types().keys, self.SLOT_TYPES):
+        for s, t in zip(self.get_fields_and_field_types().keys(), self.SLOT_TYPES):
             field = getattr(self, s)
             fieldstr = repr(field)
             # We use Python array type for fields that can be directly stored

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -253,7 +253,6 @@ string@
 @[  end if]@
 ',
 @[end for]@
-        '_check_fields': 'boolean',
     }
 
     SLOT_TYPES = (

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -289,7 +289,6 @@ if isinstance(type_, AbstractNestedType):
 @[  end if]@
 ,  # noqa: E501
 @[end for]@
-        rosidl_parser.definition.BasicType('boolean'),  # noqa: E501
     )
 
     def __init__(self, **kwargs):

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -371,7 +371,7 @@ if isinstance(type_, AbstractNestedType):
         typename.pop()
         typename.append(self.__class__.__name__)
         args = []
-        for s, t in self.get_fields_and_field_types.items():
+        for s, t in self.get_fields_and_field_types().items():
             field = getattr(self, s)
             fieldstr = repr(field)
             # We use Python array type for fields that can be directly stored

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -293,7 +293,7 @@ if isinstance(type_, AbstractNestedType):
     )
 
     def __init__(self, check_fields = False, **kwargs):
-        self._check_fields = check_fields or ge
+        self._check_fields = check_fields
         if self._check_fields:
             assert all('_' + key in self.__slots__ for key in kwargs.keys()), \
                 'Invalid arguments passed to constructor: %s' % \

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -255,6 +255,8 @@ string@
 @[end for]@
     }
 
+    # This attribute is used to store an rosidl_parser.definition variable
+    # related to the data type of each of the components the message.
     SLOT_TYPES = (
 @[for member in message.structure.members]@
 @[  if len(message.structure.members) == 1 and member.name == EMPTY_STRUCTURE_REQUIRED_MEMBER_NAME]@
@@ -370,7 +372,7 @@ if isinstance(type_, AbstractNestedType):
         typename.pop()
         typename.append(self.__class__.__name__)
         args = []
-        for s, t in self.get_fields_and_field_types().items():
+        for s, t in zip(self.get_fields_and_field_types().keys, self.SLOT_TYPES):
             field = getattr(self, s)
             fieldstr = repr(field)
             # We use Python array type for fields that can be directly stored

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -87,6 +87,10 @@ for member in message.structure.members:
 @[end if]@
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
+from os import getenv
+
+ros_python_check_fields = getenv("ROS_PYTHON_CHECK_FIELDS")
+
 
 class Metaclass_@(message.structure.namespaced_type.name)(type):
     """Metaclass of message '@(message.structure.namespaced_type.name)'."""
@@ -290,11 +294,12 @@ if isinstance(type_, AbstractNestedType):
 @[  end if]@
 ,  # noqa: E501
 @[end for]@
+        rosidl_parser.definition.BasicType('boolean'),  # noqa: E501
     )
 
-    def __init__(self, check_fields = False, **kwargs):
+    def __init__(self, check_fields=False, **kwargs):
         self._check_fields = check_fields
-        if self._check_fields:
+        if self._check_fields or ros_python_check_fields:
             assert all('_' + key in self.__slots__ for key in kwargs.keys()), \
                 'Invalid arguments passed to constructor: %s' % \
                 ', '.join(sorted(k for k in kwargs.keys() if '_' + k not in self.__slots__))
@@ -382,7 +387,7 @@ if isinstance(type_, AbstractNestedType):
                 if len(field) == 0:
                     fieldstr = '[]'
                 else:
-                    if self._check_fields:
+                    if self._check_fields or ros_python_check_fields:
                         assert fieldstr.startswith('array(')
                     prefix = "array('X', "
                     suffix = ')'
@@ -433,7 +438,7 @@ if member.name in dict(inspect.getmembers(builtins)).keys():
 
     @@@(member.name).setter@(noqa_string)
     def @(member.name)(self, value):@(noqa_string)
-        if self._check_fields:
+        if self._check_fields or ros_python_check_fields:
 @[      if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, BasicType) and member.type.value_type.typename in SPECIAL_NESTED_BASIC_TYPES]@
 @[        if isinstance(member.type, Array)]@
             if isinstance(value, numpy.ndarray):

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -371,7 +371,7 @@ if isinstance(type_, AbstractNestedType):
         typename.pop()
         typename.append(self.__class__.__name__)
         args = []
-        for s, t in zip(self.__slots__, self.SLOT_TYPES):
+        for s, t in self.get_fields_and_field_types.items():
             field = getattr(self, s)
             fieldstr = repr(field)
             # We use Python array type for fields that can be directly stored
@@ -390,7 +390,7 @@ if isinstance(type_, AbstractNestedType):
                     prefix = "array('X', "
                     suffix = ')'
                     fieldstr = fieldstr[len(prefix):-len(suffix)]
-            args.append(s[1:] + '=' + fieldstr)
+            args.append(s + '=' + fieldstr)
         return '%s(%s)' % ('.'.join(typename), ', '.join(args))
 
     def __eq__(self, other):

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -253,7 +253,7 @@ string@
 @[  end if]@
 ',
 @[end for]@
-        'check_fields': 'boolean',
+        '_check_fields': 'boolean',
     }
 
     SLOT_TYPES = (

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -92,7 +92,7 @@ for member in message.structure.members:
 # change during runtime so it makes sense to only look for it once.
 from os import getenv
 
-ros_python_check_fields = getenv("ROS_PYTHON_CHECK_FIELDS")
+ros_python_check_fields = getenv("ROS_PYTHON_CHECK_FIELDS", default='')
 
 
 class Metaclass_@(message.structure.namespaced_type.name)(type):
@@ -300,8 +300,11 @@ if isinstance(type_, AbstractNestedType):
         rosidl_parser.definition.BasicType('boolean'),  # noqa: E501
     )
 
-    def __init__(self, check_fields=False, **kwargs):
-        self._check_fields = check_fields or ros_python_check_fields
+    def __init__(self, **kwargs):
+        if 'check_fields' in kwargs:
+            self._check_fields = kwargs['check_fields']
+        else:
+            self._check_fields = self._check_fields = ros_python_check_fields == "1"
         if self._check_fields:
             assert all('_' + key in self.__slots__ for key in kwargs.keys()), \
                 'Invalid arguments passed to constructor: %s' % \

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -87,13 +87,6 @@ for member in message.structure.members:
 @[end if]@
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-# This is being done at the module level and not on the instance level to avoid looking
-# for the same variable multiple times on each instance. This variable is not supposed to
-# change during runtime so it makes sense to only look for it once.
-from os import getenv
-
-ros_python_check_fields = getenv("ROS_PYTHON_CHECK_FIELDS", default='')
-
 
 class Metaclass_@(message.structure.namespaced_type.name)(type):
     """Metaclass of message '@(message.structure.namespaced_type.name)'."""
@@ -304,7 +297,7 @@ if isinstance(type_, AbstractNestedType):
         if 'check_fields' in kwargs:
             self._check_fields = kwargs['check_fields']
         else:
-            self._check_fields = self._check_fields = ros_python_check_fields == "1"
+            self._check_fields = ros_python_check_fields == '1'
         if self._check_fields:
             assert all('_' + key in self.__slots__ for key in kwargs.keys()), \
                 'Invalid arguments passed to constructor: %s' % \

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -87,7 +87,7 @@ for member in message.structure.members:
 @[end if]@
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-# This is being done at the module level and not on the instance level to avoid looking 
+# This is being done at the module level and not on the instance level to avoid looking
 # for the same variable multiple times on each instance. This variable is not supposed to
 # change during runtime so it makes sense to only look for it once.
 from os import getenv

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -902,11 +902,8 @@ def test_slot_attributes():
     assert hasattr(msg, 'get_fields_and_field_types')
     assert hasattr(msg, '__slots__')
     nested_slot_types_dict = getattr(msg, 'get_fields_and_field_types')()
-    nested_slots = getattr(msg, '__slots__')
-    assert len(nested_slot_types_dict) == len(nested_slots)
     expected_nested_slot_types_dict = {
         'basic_types_value': 'rosidl_generator_py/BasicTypes',
-        'check_fields': 'boolean',
     }
     assert len(nested_slot_types_dict) == len(expected_nested_slot_types_dict)
 
@@ -920,8 +917,6 @@ def test_string_slot_attributes():
     assert hasattr(msg, 'get_fields_and_field_types')
     assert hasattr(msg, '__slots__')
     string_slot_types_dict = getattr(msg, 'get_fields_and_field_types')()
-    string_slots = getattr(msg, '__slots__')
-    assert len(string_slot_types_dict) == len(string_slots)
     expected_string_slot_types_dict = {
         'ub_string_static_array_value': 'string<5>[3]',
         'ub_string_ub_array_value': 'sequence<string<5>, 10>',
@@ -934,7 +929,6 @@ def test_string_slot_attributes():
         'def_string_bounded_array_value': 'sequence<string, 10>',
         'def_various_quotes': 'sequence<string>',
         'def_various_commas': 'sequence<string>',
-        'check_fields': 'boolean',
     }
 
     assert len(string_slot_types_dict) == len(expected_string_slot_types_dict)
@@ -1000,5 +994,8 @@ def test_builtin_sequence_slot_attributes():
     assert hasattr(msg, 'get_fields_and_field_types')
     assert hasattr(msg, '__slots__')
     builtin_sequence_slot_types_dict = getattr(msg, 'get_fields_and_field_types')()
-    builtin_sequence_slots = getattr(msg, '__slots__')
-    assert len(builtin_sequence_slot_types_dict) == len(builtin_sequence_slots)
+    expected_builtin_sequence_slot_types_dict = {
+        'char_sequence_unbounded': 'sequence<char>',
+    }
+
+    assert len(builtin_sequence_slot_types_dict) == len(expected_builtin_sequence_slot_types_dict)

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -952,8 +952,6 @@ def test_slot_types():
     assert hasattr(msg, 'SLOT_TYPES')
     assert hasattr(msg, '__slots__')
     nested_slot_types = Nested.SLOT_TYPES
-    nested_slots = getattr(msg, '__slots__')
-    assert len(nested_slot_types) == len(nested_slots)
     assert isinstance(nested_slot_types[0], NamespacedType)
     assert nested_slot_types[0].namespaces == ['rosidl_generator_py', 'msg']
     assert nested_slot_types[0].name == 'BasicTypes'
@@ -964,8 +962,6 @@ def test_string_slot_types():
     assert hasattr(msg, 'SLOT_TYPES')
     assert hasattr(msg, '__slots__')
     string_slot_types = StringArrays.SLOT_TYPES
-    string_slots = getattr(msg, '__slots__')
-    assert len(string_slot_types) == len(string_slots)
 
     assert isinstance(string_slot_types[0], Array)
     assert isinstance(string_slot_types[0].value_type, BoundedString)

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -40,7 +40,7 @@ from rosidl_parser.definition import UnboundedString
 
 
 def test_basic_types():
-    msg = BasicTypes()
+    msg = BasicTypes(check_fields=True)
 
     # types
     assert isinstance(msg.bool_value, bool)
@@ -149,7 +149,7 @@ def test_basic_types():
 
 
 def test_strings():
-    msg = Strings()
+    msg = Strings(check_fields=True)
 
     # types
     assert isinstance(msg.string_value, str)
@@ -203,7 +203,7 @@ def test_strings():
 
 
 def test_wstrings():
-    msg = WStrings()
+    msg = WStrings(check_fields=True)
 
     # types
     assert isinstance(msg.wstring_value, str)
@@ -217,7 +217,7 @@ def test_wstrings():
 
 
 def test_arrays_of_bounded_strings():
-    msg = StringArrays()
+    msg = StringArrays(check_fields=True)
     array_valid_string_length = ['a' * 2, 'b' * 3, 'c' * 4]
     array_too_long_strings = ['a' * 2, 'b' * 3, 'c' * 6]
     assert ['', '', ''] == msg.ub_string_static_array_value
@@ -260,12 +260,12 @@ def test_arrays_of_bounded_strings():
 
 
 def test_constructor():
-    msg = Strings(string_value='foo')
+    msg = Strings(string_value='foo', check_fields=True)
 
     assert'foo' == msg.string_value
 
     with pytest.raises(AssertionError):
-        Strings(unknown_field='test')
+        Strings(unknown_field='test', check_fields=True)
 
 
 def test_constants():
@@ -289,7 +289,7 @@ def test_constants():
 
 
 def test_default_values():
-    msg = Defaults()
+    msg = Defaults(check_fields=True)
 
     assert msg.bool_value is True
     assert bytes([50]) == msg.byte_value
@@ -316,7 +316,7 @@ def test_default_values():
 
 
 def test_arrays():
-    msg = Arrays()
+    msg = Arrays(check_fields=True)
 
     # types
     assert isinstance(msg.bool_values, list)
@@ -525,7 +525,7 @@ def test_arrays():
 
 
 def test_bounded_sequences():
-    msg = BoundedSequences()
+    msg = BoundedSequences(check_fields=True)
 
     # types
     assert isinstance(msg.bool_values, list)
@@ -749,7 +749,7 @@ def test_bounded_sequences():
 
 
 def test_unbounded_sequences():
-    msg = UnboundedSequences()
+    msg = UnboundedSequences(check_fields=True)
 
     # types
     assert isinstance(msg.byte_values, list)
@@ -898,7 +898,7 @@ def test_unbounded_sequences():
 
 
 def test_slot_attributes():
-    msg = Nested()
+    msg = Nested(check_fields=True)
     assert hasattr(msg, 'get_fields_and_field_types')
     assert hasattr(msg, '__slots__')
     nested_slot_types_dict = getattr(msg, 'get_fields_and_field_types')()
@@ -906,6 +906,7 @@ def test_slot_attributes():
     assert len(nested_slot_types_dict) == len(nested_slots)
     expected_nested_slot_types_dict = {
         'basic_types_value': 'rosidl_generator_py/BasicTypes',
+        'check_fields': 'boolean',
     }
     assert len(nested_slot_types_dict) == len(expected_nested_slot_types_dict)
 
@@ -915,7 +916,7 @@ def test_slot_attributes():
 
 
 def test_string_slot_attributes():
-    msg = StringArrays()
+    msg = StringArrays(check_fields=True)
     assert hasattr(msg, 'get_fields_and_field_types')
     assert hasattr(msg, '__slots__')
     string_slot_types_dict = getattr(msg, 'get_fields_and_field_types')()
@@ -933,6 +934,7 @@ def test_string_slot_attributes():
         'def_string_bounded_array_value': 'sequence<string, 10>',
         'def_various_quotes': 'sequence<string>',
         'def_various_commas': 'sequence<string>',
+        'check_fields': 'boolean',
     }
 
     assert len(string_slot_types_dict) == len(expected_string_slot_types_dict)
@@ -943,7 +945,7 @@ def test_string_slot_attributes():
 
 
 def test_modifying_slot_fields_and_types():
-    msg = StringArrays()
+    msg = StringArrays(check_fields=True)
     assert hasattr(msg, 'get_fields_and_field_types')
     string_slot_types_dict = getattr(msg, 'get_fields_and_field_types')()
     string_slot_types_dict_len = len(string_slot_types_dict)
@@ -952,7 +954,7 @@ def test_modifying_slot_fields_and_types():
 
 
 def test_slot_types():
-    msg = Nested()
+    msg = Nested(check_fields=True)
     assert hasattr(msg, 'SLOT_TYPES')
     assert hasattr(msg, '__slots__')
     nested_slot_types = Nested.SLOT_TYPES
@@ -964,7 +966,7 @@ def test_slot_types():
 
 
 def test_string_slot_types():
-    msg = StringArrays()
+    msg = StringArrays(check_fields=True)
     assert hasattr(msg, 'SLOT_TYPES')
     assert hasattr(msg, '__slots__')
     string_slot_types = StringArrays.SLOT_TYPES
@@ -994,7 +996,7 @@ def test_string_slot_types():
 
 
 def test_builtin_sequence_slot_attributes():
-    msg = BuiltinTypeSequencesIdl()
+    msg = BuiltinTypeSequencesIdl(check_fields=True)
     assert hasattr(msg, 'get_fields_and_field_types')
     assert hasattr(msg, '__slots__')
     builtin_sequence_slot_types_dict = getattr(msg, 'get_fields_and_field_types')()


### PR DESCRIPTION
## Context
This PR is related to the issue described in [this discussion](https://discourse.ros.org/t/high-cpu-load-for-simple-python-nodes/28324). After doing some benchmarks on simple publishers and subscribers on rclpy using different types of messages (Ex: Strings, Ints, Arrays, Custom messages with nested structures) and analyzing their behavior using flamegraphs, we noticed that a lot of the busy time of the nodes was being used during the creation of the messages object. Taking that into account, a possible area of improvement for this issue is by hiding all the assertions made on the fields of the messages under a user controlled flag.

## Description
 In summary, this PR hides all the assertions made at the time of construction of messages in rclpy. In order to give the user control whether to do the assertions (and lose performance due to this) or to not do the assertions, all the message constructors have  a new argument called `check_fields` which default value is `False`. This way all the pre-existing code would notice this improvement without the need of doing any modification.
 