### PR TITLE
Install compiled libraries only to 'lib'

### DIFF
--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -146,17 +146,13 @@ macro(set_properties _build_type)
   set_target_properties(${_target_name} PROPERTIES
     COMPILE_OPTIONS "${_extension_compile_flags}"
     PREFIX ""
-    LIBRARY_OUTPUT_DIRECTORY${_build_type} ${_output_path}
-    RUNTIME_OUTPUT_DIRECTORY${_build_type} ${_output_path}
     OUTPUT_NAME "${PROJECT_NAME}_s__${_typesupport_impl}${PythonExtra_EXTENSION_SUFFIX}"
     SUFFIX "${PythonExtra_EXTENSION_EXTENSION}")
 endmacro()
 
 macro(set_lib_properties _build_type)
   set_target_properties(${_target_name_lib} PROPERTIES
-    COMPILE_OPTIONS "${_extension_compile_flags}"
-    LIBRARY_OUTPUT_DIRECTORY${_build_type} ${_output_path}
-    RUNTIME_OUTPUT_DIRECTORY${_build_type} ${_output_path})
+    COMPILE_OPTIONS "${_extension_compile_flags}")
 endmacro()
 
 # Export target so downstream interface packages can link to it


### PR DESCRIPTION
The current behavior results in duplicate libraries installed to both the Python module in libdir and also into the global lib directory for the prefix.

The former seems unnecessary, so we should install the libraries only to lib.