### PR TITLE
Fix: Missing dependency that causes cmake error in downstream (resolves https://github.com/ros2/rosidl_python/issues/198)

### DIFF
--- a/rosidl_generator_py/package.xml
+++ b/rosidl_generator_py/package.xml
@@ -29,16 +29,16 @@
   <buildtool_export_depend>rosidl_typesupport_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_typesupport_interface</buildtool_export_depend>
 
-  <!-- BEGIN: Following 'exec_depend's are likely only needed in test in downstream,
-       so ideally "test_export_depend" (similar to 'build_export_depend') are reasonable.
-       With such a feature unexistent yet, they are 'exec_depend'-ed.
+  <!-- TODO: The following 'exec_depend's are only needed in downstream tests,
+       so ideally a 'test_export_depend' (similar to 'build_export_depend') would be used.
+       Since that feature doesn't exist yet, they are 'exec_depend'-ed.
        See https://github.com/ros2/rosidl_python/pull/199 -->
   <exec_depend>ament_cmake_cppcheck</exec_depend>
   <exec_depend>ament_cmake_cpplint</exec_depend>
   <exec_depend>ament_cmake_flake8</exec_depend>
   <exec_depend>ament_cmake_pep257</exec_depend>
   <exec_depend>ament_cmake_uncrustify</exec_depend>
-  <!-- END -->  
+
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>rosidl_cli</exec_depend>

--- a/rosidl_generator_py/package.xml
+++ b/rosidl_generator_py/package.xml
@@ -29,6 +29,8 @@
   <buildtool_export_depend>rosidl_typesupport_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_typesupport_interface</buildtool_export_depend>
 
+  <exec_depend>ament_cmake_flake8</exec_depend>
+  <exec_depend>ament_cmake_pep257</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>rosidl_cli</exec_depend>

--- a/rosidl_generator_py/package.xml
+++ b/rosidl_generator_py/package.xml
@@ -29,8 +29,16 @@
   <buildtool_export_depend>rosidl_typesupport_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_typesupport_interface</buildtool_export_depend>
 
+  <!-- BEGIN: Following 'exec_depend's are likely only needed in test in downstream,
+       so ideally "test_export_depend" (similar to 'build_export_depend') are reasonable.
+       With such a feature unexistent yet, they are 'exec_depend'-ed.
+       See https://github.com/ros2/rosidl_python/pull/199 -->
+  <exec_depend>ament_cmake_cppcheck</exec_depend>
+  <exec_depend>ament_cmake_cpplint</exec_depend>
   <exec_depend>ament_cmake_flake8</exec_depend>
   <exec_depend>ament_cmake_pep257</exec_depend>
+  <exec_depend>ament_cmake_uncrustify</exec_depend>
+  <!-- END -->  
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>rosidl_cli</exec_depend>


### PR DESCRIPTION
# Issue aimed at
- Closes https://github.com/ros2/rosidl_python/issues/198

# Changes
- Add a missing package in `package.xml`.
   - Even if that the pkg in question is only required conditionally https://github.com/ros2/rosidl_python/issues/198#issuecomment-1636500998, it makes more sense to me in the upstream (here) to install it than making it a job for downstream pkgs.
   - That said, I have little idea if the implementation I'm suggesting is the best/reasonable. Open for advises.
