### PR TITLE
Revert install of .so files into python path

### DIFF
--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -236,10 +236,6 @@ endforeach()
 
 set_target_properties(${_target_name_lib} PROPERTIES COMPILE_OPTIONS "${_extension_compile_flags}")
 
-set_target_properties(${_target_name_lib} PROPERTIES
-  LIBRARY_OUTPUT_DIRECTORY ${_output_path}
-  RUNTIME_OUTPUT_DIRECTORY ${_output_path})
-
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
   install(TARGETS ${_target_name_lib}
     EXPORT export_${_target_name_lib}


### PR DESCRIPTION
There seems that some regression might have happened after #195. When removing those 2 lines, we avoid to install the .so files in lib *and* python path.