### PR TITLE
Add rosidl_generator_py to the rosidl_runtime_packages group

### DIFF
--- a/rosidl_generator_py/package.xml
+++ b/rosidl_generator_py/package.xml
@@ -71,6 +71,7 @@
   <test_depend>test_interface_files</test_depend>
 
   <member_of_group>rosidl_generator_packages</member_of_group>
+  <member_of_group>rosidl_runtime_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Unlike the c/cpp packages, both generator and runtime facilities are provided by the same package for Python.

Corresponds to: https://github.com/ros2/rosidl_core/blob/84fa73d3974fe31fbe397e41e4449a31c2fb6ce4/rosidl_core_runtime/package.xml#L20

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=20943)](http://ci.ros2.org/job/ci_linux/20943/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=15234)](http://ci.ros2.org/job/ci_linux-aarch64/15234/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=21617)](http://ci.ros2.org/job/ci_windows/21617/)