### PR TITLE
Revamp how we check for the correct class.

### DIFF
--- a/rosidl_generator_py/resource/_msg_support.c.em
+++ b/rosidl_generator_py/resource/_msg_support.c.em
@@ -182,12 +182,9 @@ bool @('__'.join(message.structure.namespaced_type.namespaces + [convert_camel_c
       return false;
     }
 
-    // No error checking is necessary here since PyUnicode_1BYTE_DATA is just a cast
-    char * class_name = (char *)PyUnicode_1BYTE_DATA(name_attr);
-    char * module_name = (char *)PyUnicode_1BYTE_DATA(module_attr);
-
-    assert(strncmp("@(class_module)", module_name, @(len(class_module))) == 0);
-    assert(strncmp("@(namespaced_type)", class_name, @(len(namespaced_type))) == 0);
+    // PyUnicode_1BYTE_DATA is just a cast
+    assert(strncmp("@(class_module)", (char *)PyUnicode_1BYTE_DATA(module_attr), @(len(class_module))) == 0);
+    assert(strncmp("@(namespaced_type)", (char *)PyUnicode_1BYTE_DATA(name_attr), @(len(namespaced_type))) == 0);
 
     Py_DECREF(module_attr);
     Py_DECREF(name_attr);


### PR DESCRIPTION
In an issue it was pointed out that we are decref'ing before we actually use some of the data, which means that in theory the garbage collector could reclaim the data before we used it.  So the original point of this change was to fix that issue.

However, while looking at it I realized we could slightly improve performance here by avoiding a copy of the class and module into a combined string.  Instead, we can compare them separately, which should reduce the copies.

This is a partial solution to https://github.com/ros2/rosidl_python/issues/217 ; the other reported bug in there will require a much more extensive rework.