### PR TITLE
Remove use of ament_target_dependencies

### DIFF
--- a/rosidl_generator_py/CMakeLists.txt
+++ b/rosidl_generator_py/CMakeLists.txt
@@ -25,8 +25,7 @@ if(BUILD_TESTING)
   include(cmake/register_py.cmake)
   include(cmake/rosidl_generator_py_get_typesupports.cmake)
 
-  # Trick ament_target_dependencies() into thinking this package has been found
-  set(rosidl_generator_py_FOUND "1")
+  # Trick ament_execute_extensions into finding this extension in the source space
   set(rosidl_generator_py_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
   # Need to call extras before get_typesupports, to register the extension

--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -233,10 +233,6 @@ foreach(_typesupport_impl ${_typesupport_impls})
     ${rosidl_generate_interfaces_TARGET}__${_typesupport_impl}
   )
 
-  ament_target_dependencies(${_target_name} PUBLIC
-    "rosidl_generator_py"
-  )
-
   if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
     # PYTHON_INSTALL_DIR is defined by ament_cmake_python
     install(TARGETS ${_target_name}


### PR DESCRIPTION
https://github.com/ament/ament_cmake/issues/292

This removes a use of `ament_target_dependencies()` in `rosidl_generator_py` and replaces it with ... nothing!

`rosidl_generator_py` doesn't export any CMake targets or old-style standard cmake variables, so this call had no effect.