### PR TITLE
Derive Messages from Base Classes

### DIFF
--- a/rosidl_generator_py/resource/_action.py.em
+++ b/rosidl_generator_py/resource/_action.py.em
@@ -42,13 +42,7 @@ TEMPLATE(
 }@
 
 
-class Metaclass_@(action.namespaced_type.name)(
-    rosidl_pycommon.interface_base_metaclasses.ActionAbstractMeta[
-        @(action.goal.structure.namespaced_type.name),
-        @(action.result.structure.namespaced_type.name),
-        @(action.feedback.structure.namespaced_type.name)
-    ]
-):
+class Metaclass_@(action.namespaced_type.name)(rosidl_pycommon.interface_base_classes.ActionTypeSupportMeta):
     """Metaclass of action '@(action.namespaced_type.name)'."""
 
     _TYPE_SUPPORT: typing.ClassVar[typing.Optional[PyCapsule]] = None
@@ -85,14 +79,19 @@ class Metaclass_@(action.namespaced_type.name)(
                 @(module_name).Metaclass_@(action.feedback_message.structure.namespaced_type.name).__import_type_support__()
 
 
-class @(action.namespaced_type.name)(metaclass=Metaclass_@(action.namespaced_type.name)):
+class @(action.namespaced_type.name)(rosidl_pycommon.interface_base_classes.BaseAction[
+        @(action.goal.structure.namespaced_type.name),
+        @(action.result.structure.namespaced_type.name),
+        @(action.feedback.structure.namespaced_type.name)
+    ],
+metaclass=Metaclass_@(action.namespaced_type.name)):
 
     # The goal message defined in the action definition.
-    from @('.'.join(action.namespaced_type.namespaces)).@(module_name) import @(action.goal.structure.namespaced_type.name) as Goal
+    Goal: type[@(action.goal.structure.namespaced_type.name)] = @(action.goal.structure.namespaced_type.name)
     # The result message defined in the action definition.
-    from @('.'.join(action.namespaced_type.namespaces)).@(module_name) import @(action.result.structure.namespaced_type.name) as Result
+    Result: type[@(action.result.structure.namespaced_type.name)] = @(action.result.structure.namespaced_type.name)
     # The feedback message defined in the action definition.
-    from @('.'.join(action.namespaced_type.namespaces)).@(module_name) import @(action.feedback.structure.namespaced_type.name) as Feedback
+    Feedback: type[@(action.feedback.structure.namespaced_type.name)] = @(action.feedback.structure.namespaced_type.name)
 
     class Impl:
 

--- a/rosidl_generator_py/resource/_action.py.em
+++ b/rosidl_generator_py/resource/_action.py.em
@@ -42,7 +42,13 @@ TEMPLATE(
 }@
 
 
-class Metaclass_@(action.namespaced_type.name)(type):
+class Metaclass_@(action.namespaced_type.name)(
+    rosidl_pycommon.message_base_metaclasses.ActionAbstractMeta[
+        @(action.goal.structure.namespaced_type.name),
+        @(action.result.structure.namespaced_type.name),
+        @(action.feedback.structure.namespaced_type.name)
+    ]
+):
     """Metaclass of action '@(action.namespaced_type.name)'."""
 
     _TYPE_SUPPORT: typing.ClassVar[typing.Optional[PyCapsule]] = None

--- a/rosidl_generator_py/resource/_action.py.em
+++ b/rosidl_generator_py/resource/_action.py.em
@@ -43,7 +43,7 @@ TEMPLATE(
 
 
 class Metaclass_@(action.namespaced_type.name)(
-    rosidl_pycommon.message_base_metaclasses.ActionAbstractMeta[
+    rosidl_pycommon.interface_base_metaclasses.ActionAbstractMeta[
         @(action.goal.structure.namespaced_type.name),
         @(action.result.structure.namespaced_type.name),
         @(action.feedback.structure.namespaced_type.name)

--- a/rosidl_generator_py/resource/_action.py.em
+++ b/rosidl_generator_py/resource/_action.py.em
@@ -80,9 +80,9 @@ class Metaclass_@(action.namespaced_type.name)(rosidl_pycommon.interface_base_cl
 
 
 class @(action.namespaced_type.name)(rosidl_pycommon.interface_base_classes.BaseAction[
-        @(action.goal.structure.namespaced_type.name),
-        @(action.result.structure.namespaced_type.name),
-        @(action.feedback.structure.namespaced_type.name)
+    @(action.goal.structure.namespaced_type.name),
+    @(action.result.structure.namespaced_type.name),
+    @(action.feedback.structure.namespaced_type.name)
 ], metaclass=Metaclass_@(action.namespaced_type.name)):
 
     # The goal message defined in the action definition.

--- a/rosidl_generator_py/resource/_action.py.em
+++ b/rosidl_generator_py/resource/_action.py.em
@@ -83,8 +83,7 @@ class @(action.namespaced_type.name)(rosidl_pycommon.interface_base_classes.Base
         @(action.goal.structure.namespaced_type.name),
         @(action.result.structure.namespaced_type.name),
         @(action.feedback.structure.namespaced_type.name)
-    ],
-metaclass=Metaclass_@(action.namespaced_type.name)):
+], metaclass=Metaclass_@(action.namespaced_type.name)):
 
     # The goal message defined in the action definition.
     Goal: type[@(action.goal.structure.namespaced_type.name)] = @(action.goal.structure.namespaced_type.name)

--- a/rosidl_generator_py/resource/_idl.py.em
+++ b/rosidl_generator_py/resource/_idl.py.em
@@ -8,7 +8,7 @@ import collections.abc
 from os import getenv
 import typing
 
-import rosidl_pycommon.interface_base_metaclasses
+import rosidl_pycommon.interface_base_classes
 
 # This is being done at the module level and not on the instance level to avoid looking
 # for the same variable multiple times on each instance. This variable is not supposed to

--- a/rosidl_generator_py/resource/_idl.py.em
+++ b/rosidl_generator_py/resource/_idl.py.em
@@ -8,7 +8,7 @@ import collections.abc
 from os import getenv
 import typing
 
-import rosidl_pycommon.message_base_metaclasses
+import rosidl_pycommon.interface_base_metaclasses
 
 # This is being done at the module level and not on the instance level to avoid looking
 # for the same variable multiple times on each instance. This variable is not supposed to

--- a/rosidl_generator_py/resource/_idl.py.em
+++ b/rosidl_generator_py/resource/_idl.py.em
@@ -8,6 +8,8 @@ import collections.abc
 from os import getenv
 import typing
 
+import rosidl_pycommon.message_base_metaclasses
+
 # This is being done at the module level and not on the instance level to avoid looking
 # for the same variable multiple times on each instance. This variable is not supposed to
 # change during runtime so it makes sense to only look for it once.

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -138,7 +138,7 @@ for member in message.structure.members:
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 
-class Metaclass_@(message.structure.namespaced_type.name)(rosidl_pycommon.message_base_metaclasses.MessageAbstractMeta):
+class Metaclass_@(message.structure.namespaced_type.name)(rosidl_pycommon.interface_base_metaclasses.MessageAbstractMeta):
     """Metaclass of message '@(message.structure.namespaced_type.name)'."""
 
     _CREATE_ROS_MESSAGE: typing.ClassVar[typing.Optional[PyCapsule]] = None

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -138,7 +138,7 @@ for member in message.structure.members:
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 
-class Metaclass_@(message.structure.namespaced_type.name)(rosidl_pycommon.interface_base_metaclasses.MessageAbstractMeta):
+class Metaclass_@(message.structure.namespaced_type.name)(rosidl_pycommon.interface_base_classes.MessageTypeSupportMeta):
     """Metaclass of message '@(message.structure.namespaced_type.name)'."""
 
     _CREATE_ROS_MESSAGE: typing.ClassVar[typing.Optional[PyCapsule]] = None
@@ -244,7 +244,7 @@ for member in message.structure.members:
 @[end for]@
 
 
-class @(message.structure.namespaced_type.name)(metaclass=Metaclass_@(message.structure.namespaced_type.name)):
+class @(message.structure.namespaced_type.name)(rosidl_pycommon.interface_base_classes.BaseMessage, metaclass=Metaclass_@(message.structure.namespaced_type.name)):
 @[if not message.constants]@
     """Message class '@(message.structure.namespaced_type.name)'."""
 @[else]@

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -138,7 +138,7 @@ for member in message.structure.members:
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 
-class Metaclass_@(message.structure.namespaced_type.name)(type):
+class Metaclass_@(message.structure.namespaced_type.name)(rosidl_pycommon.message_base_metaclasses.MessageAbstractMeta):
     """Metaclass of message '@(message.structure.namespaced_type.name)'."""
 
     _CREATE_ROS_MESSAGE: typing.ClassVar[typing.Optional[PyCapsule]] = None

--- a/rosidl_generator_py/resource/_srv.py.em
+++ b/rosidl_generator_py/resource/_srv.py.em
@@ -27,7 +27,7 @@ TEMPLATE(
 
 
 class Metaclass_@(service.namespaced_type.name)(
-    rosidl_pycommon.message_base_metaclasses.ServiceAbstractMeta[
+    rosidl_pycommon.interface_base_metaclasses.ServiceAbstractMeta[
         @(service.request_message.structure.namespaced_type.name),
         @(service.response_message.structure.namespaced_type.name)
     ]

--- a/rosidl_generator_py/resource/_srv.py.em
+++ b/rosidl_generator_py/resource/_srv.py.em
@@ -26,12 +26,7 @@ TEMPLATE(
 }@
 
 
-class Metaclass_@(service.namespaced_type.name)(
-    rosidl_pycommon.interface_base_metaclasses.ServiceAbstractMeta[
-        @(service.request_message.structure.namespaced_type.name),
-        @(service.response_message.structure.namespaced_type.name)
-    ]
-):
+class Metaclass_@(service.namespaced_type.name)(rosidl_pycommon.interface_base_classes.ServiceTypeSupportMeta):
     """Metaclass of service '@(service.namespaced_type.name)'."""
 
     _TYPE_SUPPORT: typing.ClassVar[typing.Optional[PyCapsule]] = None
@@ -61,9 +56,12 @@ class Metaclass_@(service.namespaced_type.name)(
                 @(module_name).Metaclass_@(service.event_message.structure.namespaced_type.name).__import_type_support__()
 
 
-class @(service.namespaced_type.name)(metaclass=Metaclass_@(service.namespaced_type.name)):
-    from @('.'.join(service.namespaced_type.namespaces)).@(module_name) import @(service.request_message.structure.namespaced_type.name) as Request
-    from @('.'.join(service.namespaced_type.namespaces)).@(module_name) import @(service.response_message.structure.namespaced_type.name) as Response
+class @(service.namespaced_type.name)(rosidl_pycommon.interface_base_classes.BaseService[
+    @(service.request_message.structure.namespaced_type.name),
+    @(service.response_message.structure.namespaced_type.name)
+], metaclass=Metaclass_@(service.namespaced_type.name)):
+    Request: type[@(service.request_message.structure.namespaced_type.name)] = @(service.request_message.structure.namespaced_type.name)
+    Response: type[@(service.response_message.structure.namespaced_type.name)] = @(service.response_message.structure.namespaced_type.name)
     from @('.'.join(service.namespaced_type.namespaces)).@(module_name) import @(service.event_message.structure.namespaced_type.name) as Event
 
     # Should eventually be typing.NoReturn. See mypy#14044

--- a/rosidl_generator_py/resource/_srv.py.em
+++ b/rosidl_generator_py/resource/_srv.py.em
@@ -26,7 +26,12 @@ TEMPLATE(
 }@
 
 
-class Metaclass_@(service.namespaced_type.name)(type):
+class Metaclass_@(service.namespaced_type.name)(
+    rosidl_pycommon.message_base_metaclasses.ServiceAbstractMeta[
+        @(service.request_message.structure.namespaced_type.name),
+        @(service.response_message.structure.namespaced_type.name)
+    ]
+):
     """Metaclass of service '@(service.namespaced_type.name)'."""
 
     _TYPE_SUPPORT: typing.ClassVar[typing.Optional[PyCapsule]] = None


### PR DESCRIPTION
## Description

Having messages inherit from a common base class will make it so `Client`/`Service`/`ActionClient`/`ActionServer` can automatically infer the generic types they are using. Currently they need to be manually specified.

Based on the original issue but the base classes in `rosidl_pycommon`.
Builds off https://github.com/ros2/rosidl/pull/887

Fixes #215 

### Is this user-facing behavior change?

It would allow users to isinstance check to determine if an object is a message. 

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
