### PR TITLE
Remove redudant `numpy.array()` 

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -401,8 +401,7 @@ if isinstance(type_, AbstractNestedType):
         if @(member.name) is None:
             self.@(member.name) = numpy.zeros(@(member.type.size), dtype=@(SPECIAL_NESTED_BASIC_TYPES[member.type.value_type.typename]['dtype']))
         else:
-            self.@(member.name) = numpy.array(@(member.name), dtype=@(SPECIAL_NESTED_BASIC_TYPES[member.type.value_type.typename]['dtype']))
-            assert self.@(member.name).shape == (@(member.type.size), )
+            self.@(member.name) = @(member.name)
 @[        else]@
         self.@(member.name) = @(member.name) if @(member.name) is not None else [@(get_python_type(type_))() for x in range(@(member.type.size))]
 @[        end if]@


### PR DESCRIPTION
## Description

When constructing a msg for a field that is stored in a `numpy` array it calls the `numpy.array()`  in the constructor and then again inside the property setter. This only seems to be the case for these arrays for whatever reason. For `array.array` backed field for example it does the conversion within the setter property. For the message I tested where I set all 11 `numpy` array back fields it resulted in a 15-20% speed improvement on construction.

Methodology

```python
def make_array() -> Arrays:
    return Arrays(
            char_values=[0, 1, 2],
            float32_values=[1.0, 2.0, 3.0],
            float64_values=[4.0, 5.0, 6.0],
            int8_values=[3, 4, 5],
            uint8_values=[6, 7, 8],
            int16_values=[1, 2, 3],
            uint16_values=[1, 2, 3],
            int32_values=[1, 2, 3],
            uint32_values=[1, 2, 3],
            int64_values=[1, 2, 3],
            uint64_values=[1, 2, 3]
        )


def test_timing() -> None:

    out = timeit.repeat(
        make_array,
        repeat=10000000,
        number=1
    )
    med = statistics.median(out)
    mean = statistics.mean(out)
    mode = statistics.mode(out)

    assert f'median: {med}, mean: {mean}, mode: {mode}' == 0
```

Collected data

100,000 Instantiates repeated 100 times

No duplicate np.array call
median: 1.7657687720002286, mean: 1.7685977168901081, mode: 1.8006701040012558
Duplicated np.array call
median: 2.1092314300003636, mean: 2.110108332149866, mode: 2.1043354339999496

1 Instantiates repeated 1,000,000 times
No duplicate np.array call
median: 1.8749997252598405e-05, mean: 1.866378419397697e-05, mode: 1.8961000023409724e-05
Duplicated np.array call
median: 2.242299888166599e-05, mean: 2.229084920763089e-05, mode: 2.2606000129599124e-05


### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
