### PR TITLE
[kilted] Remove redudant numpy.array() backport #232

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -342,8 +342,7 @@ if isinstance(type_, AbstractNestedType):
         if '@(member.name)' not in kwargs:
             self.@(member.name) = numpy.zeros(@(member.type.size), dtype=@(SPECIAL_NESTED_BASIC_TYPES[member.type.value_type.typename]['dtype']))
         else:
-            self.@(member.name) = numpy.array(kwargs.get('@(member.name)'), dtype=@(SPECIAL_NESTED_BASIC_TYPES[member.type.value_type.typename]['dtype']))
-            assert self.@(member.name).shape == (@(member.type.size), )
+            self.@(member.name) = kwargs.get('@(member.name)')
 @[        else]@
         self.@(member.name) = kwargs.get(
             '@(member.name)',


### PR DESCRIPTION
## Description

Backport of #232 for Kilted. This one should be more generally backportable I think.

### Is this user-facing behavior change?
No

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
