### PR TITLE
Extract imports out from `__init__()` and `__type_support__()`

### DIFF
--- a/rosidl_generator_py/CMakeLists.txt
+++ b/rosidl_generator_py/CMakeLists.txt
@@ -45,6 +45,8 @@ if(BUILD_TESTING)
     # The alternative style (just using ${PROJECT_NAME}) is used by most interface packages.
     rosidl_generate_interfaces(${PROJECT_NAME}_custom
       ${test_interface_files_MSG_FILES}
+      ${test_interface_files_SRV_FILES}
+      ${test_interface_files_ACTION_FILES}
       # Cases not covered by test_interface_files
       msg/BuiltinTypeSequencesIdl.idl
       msg/StringArrays.msg

--- a/rosidl_generator_py/CMakeLists.txt
+++ b/rosidl_generator_py/CMakeLists.txt
@@ -45,8 +45,6 @@ if(BUILD_TESTING)
     # The alternative style (just using ${PROJECT_NAME}) is used by most interface packages.
     rosidl_generate_interfaces(${PROJECT_NAME}_custom
       ${test_interface_files_MSG_FILES}
-      ${test_interface_files_SRV_FILES}
-      ${test_interface_files_ACTION_FILES}
       # Cases not covered by test_interface_files
       msg/BuiltinTypeSequencesIdl.idl
       msg/StringArrays.msg

--- a/rosidl_generator_py/resource/_action.py.em
+++ b/rosidl_generator_py/resource/_action.py.em
@@ -42,6 +42,10 @@ TEMPLATE(
 }@
 
 
+from action_msgs.msg._goal_status_array import Metaclass_GoalStatusArray  # noqa: E402, I100
+from action_msgs.srv._cancel_goal import Metaclass_CancelGoal  # noqa: E402, I100
+
+
 class Metaclass_@(action.namespaced_type.name)(rosidl_pycommon.interface_base_classes.ActionTypeSupportMeta):
     """Metaclass of action '@(action.namespaced_type.name)'."""
 
@@ -50,7 +54,7 @@ class Metaclass_@(action.namespaced_type.name)(rosidl_pycommon.interface_base_cl
     @@classmethod
     def __import_type_support__(cls) -> None:
         try:
-            from rosidl_generator_py import import_type_support
+            from rosidl_generator_py import import_type_support  # type: ignore[attr-defined]
             module = import_type_support('@(package_name)')
         except ImportError:
             import logging
@@ -63,20 +67,17 @@ class Metaclass_@(action.namespaced_type.name)(rosidl_pycommon.interface_base_cl
         else:
             cls._TYPE_SUPPORT = module.type_support_action__@('__'.join(action.namespaced_type.namespaces[1:]))_@(action_name)
 
-            from action_msgs.msg import _goal_status_array
-            if _goal_status_array.Metaclass_GoalStatusArray._TYPE_SUPPORT is None:
-                _goal_status_array.Metaclass_GoalStatusArray.__import_type_support__()
-            from action_msgs.srv import _cancel_goal
-            if _cancel_goal.Metaclass_CancelGoal._TYPE_SUPPORT is None:
-                _cancel_goal.Metaclass_CancelGoal.__import_type_support__()
+            if Metaclass_GoalStatusArray._TYPE_SUPPORT is None:
+                Metaclass_GoalStatusArray.__import_type_support__()
+            if Metaclass_CancelGoal._TYPE_SUPPORT is None:
+                Metaclass_CancelGoal.__import_type_support__()
 
-            from @('.'.join(action.namespaced_type.namespaces)) import @(module_name)
-            if @(module_name).Metaclass_@(action.send_goal_service.namespaced_type.name)._TYPE_SUPPORT is None:
-                @(module_name).Metaclass_@(action.send_goal_service.namespaced_type.name).__import_type_support__()
-            if @(module_name).Metaclass_@(action.get_result_service.namespaced_type.name)._TYPE_SUPPORT is None:
-                @(module_name).Metaclass_@(action.get_result_service.namespaced_type.name).__import_type_support__()
-            if @(module_name).Metaclass_@(action.feedback_message.structure.namespaced_type.name)._TYPE_SUPPORT is None:
-                @(module_name).Metaclass_@(action.feedback_message.structure.namespaced_type.name).__import_type_support__()
+            if Metaclass_@(action.send_goal_service.namespaced_type.name)._TYPE_SUPPORT is None:
+                Metaclass_@(action.send_goal_service.namespaced_type.name).__import_type_support__()
+            if Metaclass_@(action.get_result_service.namespaced_type.name)._TYPE_SUPPORT is None:
+                Metaclass_@(action.get_result_service.namespaced_type.name).__import_type_support__()
+            if Metaclass_@(action.feedback_message.structure.namespaced_type.name)._TYPE_SUPPORT is None:
+                Metaclass_@(action.feedback_message.structure.namespaced_type.name).__import_type_support__()
 
 
 class @(action.namespaced_type.name)(rosidl_pycommon.interface_base_classes.BaseAction[

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -97,6 +97,18 @@ for member in message.structure.members:
     if isinstance(type_, BasicType) and type_.typename in FLOATING_POINT_TYPES:
         imports.setdefault(
             'import math', [])  # used for math.isinf
+    if isinstance(type_, NamespacedType):
+        if not (
+            type_.name.endswith(SERVICE_RESPONSE_MESSAGE_SUFFIX) or
+            type_.name.endswith(SERVICE_REQUEST_MESSAGE_SUFFIX) or 
+            type_.name.endswith(ACTION_GOAL_SUFFIX) or
+            type_.name.endswith(ACTION_RESULT_SUFFIX) or
+            type_.name.endswith(ACTION_FEEDBACK_SUFFIX)
+        ):
+            joined_type_namespaces = '.'.join(type_.namespaces)
+            imports.setdefault(
+                    f'from {joined_type_namespaces}._{convert_camel_case_to_lower_case_underscore(type_.name)} import {type_.name}',
+                    [])
     if (
         isinstance(member.type, AbstractNestedType) and
         isinstance(member.type.value_type, BasicType) and
@@ -199,16 +211,15 @@ for member in message.structure.members:
             type_.name.endswith(ACTION_FEEDBACK_SUFFIX)
         ):
             action_name, suffix = type_.name.rsplit('_', 1)
-            typename = (*type_.namespaces, action_name, action_name + '.' + suffix)
+            typename = action_name + '.' + suffix
         else:
-            typename = (*type_.namespaces, type_.name, type_.name)
+            typename = type_.name
         importable_typesupports.add(typename)
 }@
 @[for typename in sorted(importable_typesupports)]@
 
-            from @('.'.join(typename[:-2])) import @(typename[-2])
-            if @(typename[-1])._TYPE_SUPPORT is None:
-                @(typename[-1]).__import_type_support__()
+            if @(typename)._TYPE_SUPPORT is None:
+                @(typename).__import_type_support__()
 @[end for]@
 
     @@classmethod
@@ -380,17 +391,6 @@ if isinstance(type_, AbstractNestedType):
 @[  if member.has_annotation('default')]@
         self.@(member.name) = @(member.name) if @(member.name) is not None else @(message.structure.namespaced_type.name).@(member.name.upper())__DEFAULT
 @[  else]@
-@[    if isinstance(type_, NamespacedType) and not isinstance(member.type, AbstractSequence)]@
-@[      if (
-            type_.name.endswith(ACTION_GOAL_SUFFIX) or
-            type_.name.endswith(ACTION_RESULT_SUFFIX) or
-            type_.name.endswith(ACTION_FEEDBACK_SUFFIX)
-        )]@
-        from @('.'.join(type_.namespaces))._@(convert_camel_case_to_lower_case_underscore(type_.name.rsplit('_', 1)[0])) import @(type_.name)
-@[      else]@
-        from @('.'.join(type_.namespaces)) import @(type_.name)
-@[      end if]@
-@[    end if]@
 @[    if isinstance(member.type, Array)]@
 @[      if isinstance(type_, BasicType) and type_.typename == 'octet']@
         self.@(member.name) = @(member.name) if @(member.name) is not None else [bytes([0]) for x in range(@(member.type.size))]
@@ -515,17 +515,6 @@ if isinstance(member.type, (Array, AbstractSequence)):
                 self._@(member.name) = value
                 return
 @[    end if]@
-@[  end if]@
-@[  if isinstance(type_, NamespacedType)]@
-@[      if (
-            type_.name.endswith(ACTION_GOAL_SUFFIX) or
-            type_.name.endswith(ACTION_RESULT_SUFFIX) or
-            type_.name.endswith(ACTION_FEEDBACK_SUFFIX)
-        )]@
-            from @('.'.join(type_.namespaces))._@(convert_camel_case_to_lower_case_underscore(type_.name.rsplit('_', 1)[0])) import @(type_.name)
-@[      else]@
-            from @('.'.join(type_.namespaces)) import @(type_.name)
-@[      end if]@
 @[  end if]@
 @[  if isinstance(member.type, AbstractNestedType)]@
             from collections.abc import Sequence

--- a/rosidl_generator_py/resource/_srv.py.em
+++ b/rosidl_generator_py/resource/_srv.py.em
@@ -34,7 +34,7 @@ class Metaclass_@(service.namespaced_type.name)(rosidl_pycommon.interface_base_c
     @@classmethod
     def __import_type_support__(cls) -> None:
         try:
-            from rosidl_generator_py import import_type_support
+            from rosidl_generator_py import import_type_support  # type: ignore[attr-defined]
             module = import_type_support('@(package_name)')
         except ImportError:
             import logging
@@ -47,13 +47,12 @@ class Metaclass_@(service.namespaced_type.name)(rosidl_pycommon.interface_base_c
         else:
             cls._TYPE_SUPPORT = module.type_support_srv__@('__'.join(service.namespaced_type.namespaces[1:]))_@(service_name)
 
-            from @('.'.join(service.namespaced_type.namespaces)) import @(module_name)
-            if @(module_name).Metaclass_@(service.request_message.structure.namespaced_type.name)._TYPE_SUPPORT is None:
-                @(module_name).Metaclass_@(service.request_message.structure.namespaced_type.name).__import_type_support__()
-            if @(module_name).Metaclass_@(service.response_message.structure.namespaced_type.name)._TYPE_SUPPORT is None:
-                @(module_name).Metaclass_@(service.response_message.structure.namespaced_type.name).__import_type_support__()
-            if @(module_name).Metaclass_@(service.event_message.structure.namespaced_type.name)._TYPE_SUPPORT is None:
-                @(module_name).Metaclass_@(service.event_message.structure.namespaced_type.name).__import_type_support__()
+            if Metaclass_@(service.request_message.structure.namespaced_type.name)._TYPE_SUPPORT is None:
+                Metaclass_@(service.request_message.structure.namespaced_type.name).__import_type_support__()
+            if Metaclass_@(service.response_message.structure.namespaced_type.name)._TYPE_SUPPORT is None:
+                Metaclass_@(service.response_message.structure.namespaced_type.name).__import_type_support__()
+            if Metaclass_@(service.event_message.structure.namespaced_type.name)._TYPE_SUPPORT is None:
+                Metaclass_@(service.event_message.structure.namespaced_type.name).__import_type_support__()
 
 
 class @(service.namespaced_type.name)(rosidl_pycommon.interface_base_classes.BaseService[

--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -24,9 +24,6 @@ from rosidl_parser.definition import AbstractNestedType
 from rosidl_parser.definition import AbstractSequence
 from rosidl_parser.definition import AbstractType
 from rosidl_parser.definition import Action
-from rosidl_parser.definition import ACTION_FEEDBACK_SUFFIX
-from rosidl_parser.definition import ACTION_GOAL_SUFFIX
-from rosidl_parser.definition import ACTION_RESULT_SUFFIX
 from rosidl_parser.definition import Array
 from rosidl_parser.definition import BasicType
 from rosidl_parser.definition import CHARACTER_TYPES
@@ -434,18 +431,6 @@ def get_setter_and_getter_type(member: Member, type_imports: set[str]) -> tuple[
         type_annotation = 'typing.Union[bytes, collections.abc.ByteString]'
     else:
         type_annotation = python_type
-
-    if isinstance(type_, NamespacedType):
-        joined_type_namespaces = '.'.join(type_.namespaces)
-        if type_.name.endswith(ACTION_GOAL_SUFFIX) or type_.name.endswith(ACTION_RESULT_SUFFIX) \
-           or type_.name.endswith(ACTION_FEEDBACK_SUFFIX):
-
-            type_name_rsplit = type_.name.rsplit('_', 1)
-            lower_case_name = convert_camel_case_to_lower_case_underscore(type_name_rsplit[0])
-            type_imports.add(f'from {joined_type_namespaces}._{lower_case_name} '
-                             f'import {type_.name}')
-        else:
-            type_imports.add(f'from {joined_type_namespaces} import {type_.name}')
 
     type_annotations_setter = type_annotation
 


### PR DESCRIPTION
## Description

For about a `5%` speed up in message construction times and simplification of importing logic by moving imports out of `__init__()` and  `__type_support__()` .

All part of a grand plan to maybe support `Optional` Idl types by further simplify the `__init__()` method.

### Is this user-facing behavior change?

No only internals should change.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
