### PR TITLE
Add DEPENDS_EXPLICIT_ONLY to remove implicit dependencies

### DIFF
--- a/rosidl_generator_py/cmake/custom_command.cmake
+++ b/rosidl_generator_py/cmake/custom_command.cmake
@@ -18,6 +18,7 @@
 # CMake does not allow `add_custom_command()` to depend on files generated in
 # a different CMake subdirectory, and this command is invoked after an
 # add_subdirectory() call.
+cmake_minimum_required(VERSION 3.27) # Required by option DEPENDS_EXPLICIT_ONLY of add_custom_command
 add_custom_command(
   OUTPUT ${_generated_extension_files} ${_generated_py_files} ${_generated_c_files}
   # This assumes that python_cmake_module was found, which is always the case since this is only
@@ -28,6 +29,7 @@ add_custom_command(
   DEPENDS ${target_dependencies} ${rosidl_generate_interfaces_TARGET}
   COMMENT "Generating Python code for ROS interfaces"
   VERBATIM
+  DEPENDS_EXPLICIT_ONLY
 )
 
 if(TARGET ${rosidl_generate_interfaces_TARGET}${_target_suffix})

--- a/rosidl_generator_py/cmake/custom_command.cmake
+++ b/rosidl_generator_py/cmake/custom_command.cmake
@@ -18,7 +18,12 @@
 # CMake does not allow `add_custom_command()` to depend on files generated in
 # a different CMake subdirectory, and this command is invoked after an
 # add_subdirectory() call.
-cmake_minimum_required(VERSION 3.27) # Required by option DEPENDS_EXPLICIT_ONLY of add_custom_command
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.27)
+  set(_dep_explicit_only DEPENDS_EXPLICIT_ONLY)
+else()
+  set(_dep_explicit_only "")
+endif()
+
 add_custom_command(
   OUTPUT ${_generated_extension_files} ${_generated_py_files} ${_generated_c_files}
   # This assumes that python_cmake_module was found, which is always the case since this is only
@@ -29,7 +34,7 @@ add_custom_command(
   DEPENDS ${target_dependencies} ${rosidl_generate_interfaces_TARGET}
   COMMENT "Generating Python code for ROS interfaces"
   VERBATIM
-  DEPENDS_EXPLICIT_ONLY
+  ${_dep_explicit_only}
 )
 
 if(TARGET ${rosidl_generate_interfaces_TARGET}${_target_suffix})


### PR DESCRIPTION
## Description

~~In Draft until https://github.com/ros2/rosidl/pull/910 is reviewed.~~

When add_custom_command is used to generate files that are then used by a target, the add_custom_command becomes implicitly dependent on the target dependencies. In rosidl add_custom_command is used to generate files from the IDL files, the generator does not depend on anything else.

This PR (and the equivalent for https://github.com/ros2/rosidl/pull/910, https://github.com/ros2/rosidl_typesupport_fastrtps/pull/136 and https://github.com/ros2/rosidl_typesupport/pull/168) adds the DEPENDS_EXPLICIT_ONLY option of [add_custom_command](https://cmake.org/cmake/help/latest/command/add_custom_command.html) to most generators.

See https://github.com/ros2/rosidl/pull/910 for more details

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

- https://github.com/ros2/rosidl/pull/910
- https://github.com/ros2/rosidl_typesupport_fastrtps/pull/136
- https://github.com/ros2/rosidl_typesupport/pull/168