### PR TITLE
Deprecate using set for container based input

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -500,7 +500,7 @@ if isinstance(member.type, (Array, AbstractSequence)):
         if isinstance(value, Set):
             import warnings
             warnings.warn(
-                'Using set or subclass of set is deprecated'
+                'Using set or subclass of set is deprecated,'
                 ' please use a subclass of collections.abc.Sequence like list',
                 DeprecationWarning)
 @[  end if]@

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -503,7 +503,6 @@ if isinstance(member.type, (Array, AbstractSequence)):
                 'Using set or subclass of set is deprecated'
                 ' please use a subclass of collections.abc.Sequence like list',
                 DeprecationWarning)
-
 @[  end if]@
         if self._check_fields:
 @[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, BasicType) and member.type.value_type.typename in SPECIAL_NESTED_BASIC_TYPES]@

--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -494,6 +494,17 @@ if isinstance(member.type, (Array, AbstractSequence)):
 
     @@@(member.name).setter@(noqa_string)
     def @(member.name)(self, value: @(type_annotations_setter[member.name])) -> None:@(noqa_string)
+
+@[  if isinstance(member.type, AbstractNestedType)]@
+        from collections.abc import Set
+        if isinstance(value, Set):
+            import warnings
+            warnings.warn(
+                'Using set or subclass of set is deprecated'
+                ' please use a subclass of collections.abc.Sequence like list',
+                DeprecationWarning)
+
+@[  end if]@
         if self._check_fields:
 @[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, BasicType) and member.type.value_type.typename in SPECIAL_NESTED_BASIC_TYPES]@
 @[    if isinstance(member.type, Array)]@
@@ -529,8 +540,6 @@ if isinstance(member.type, (Array, AbstractSequence)):
 @[  end if]@
 @[  if isinstance(member.type, AbstractNestedType)]@
             from collections.abc import Sequence
-            from collections.abc import Set
-            from collections import UserList
             from collections import UserString
 @[  elif isinstance(type_, AbstractGenericString) and type_.has_maximum_size()]@
             from collections import UserString
@@ -540,11 +549,10 @@ if isinstance(member.type, (Array, AbstractSequence)):
             assert \
 @[  if isinstance(member.type, AbstractNestedType)]@
                 ((isinstance(value, Sequence) or
-                  isinstance(value, Set) or
-                  isinstance(value, UserList)) and
+                  isinstance(value, Set)) and
                  not isinstance(value, str) and
                  not isinstance(value, UserString) and
-@{assert_msg_suffixes = ['a set or sequence']}@
+@{assert_msg_suffixes = ['sequence']}@
 @[    if isinstance(type_, AbstractGenericString) and type_.has_maximum_size()]@
                  all(len(val) <= @(type_.maximum_size) for val in value) and
 @{assert_msg_suffixes.append('and each string value not longer than %d' % type_.maximum_size)}@

--- a/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
+++ b/rosidl_generator_py/rosidl_generator_py/generate_py_impl.py
@@ -414,14 +414,13 @@ def get_setter_and_getter_type(member: Member, type_imports: set[str]) -> tuple[
         type_annotations_getter = f'typing.Annotated[typing.Any, {type_annotation}]'
 
     if isinstance(member.type, AbstractNestedType):
-        if type_annotation != '':
-            type_annotation = f'{type_annotation}, '
-        type_annotation = (f'typing.Union[{type_annotation}'
-                           f'collections.abc.Sequence[{python_type}], '
-                           f'collections.abc.Set[{python_type}], '
-                           f'collections.UserList[{python_type}]]')
+        sequence_type = f'collections.abc.Sequence[{python_type}]'
 
-        type_imports.add('import collections')
+        if type_annotation != '':
+            type_annotation = f'typing.Union[{type_annotation}, {sequence_type}]'
+        else:
+            type_annotation = sequence_type
+
     elif isinstance(member.type, AbstractGenericString) and member.type.has_maximum_size():
         type_annotation = 'typing.Union[str, collections.UserString]'
 

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -529,6 +529,9 @@ def test_arrays() -> None:
 
     assert msg2 != msg3
 
+    with pytest.warns(DeprecationWarning):
+        Arrays(string_values={'bar', 'baz', 'foo'})
+
 
 def test_bounded_sequences() -> None:
     msg = BoundedSequences(check_fields=True)


### PR DESCRIPTION
## Description

As discussed [here](https://github.com/ros2/ros2_documentation/issues/5820). This currently doesn't work at all since message are getting re-ordered in flight. Never caught since no unit test was running with a set. I can't imagine anyone is actually using this in production since it just doesn't work. Only a deprecation instead of outright removal is the fact it has existed broken for 9 years.

Also removed the `UserList` checks since isinstance() checks for subclasses and `UserList` is a subclass of `Sequence` so it was never being triggered.

### Is this user-facing behavior change?

Yes, users cannot pass in sets anymore.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
