### PR TITLE
Fix issue #1679: Add deprecation of interface variables

### DIFF
--- a/rosidl_generator_py/resource/_msg.py.em
+++ b/rosidl_generator_py/resource/_msg.py.em
@@ -431,11 +431,25 @@ if member.name in dict(inspect.getmembers(builtins)).keys():
 }@
     @@builtins.property@(noqa_string)
     def @(member.name)(self):@(noqa_string)
+@[  if member.has_annotation('deprecated')]@
+        import warnings
+        warnings.warn(
+            "field '@(member.name)' in '@(message.structure.namespaced_type.name)' is deprecated",
+            DeprecationWarning,
+            stacklevel=2)
+@[  end if]@
         """Message field '@(member.name)'."""
         return self._@(member.name)
 
     @@@(member.name).setter@(noqa_string)
     def @(member.name)(self, value):@(noqa_string)
+@[  if member.has_annotation('deprecated')]@
+        import warnings
+        warnings.warn(
+            "field '@(member.name)' in '@(message.structure.namespaced_type.name)' is deprecated",
+            DeprecationWarning,
+            stacklevel=2)
+@[  end if]@
         if self._check_fields:
 @[  if isinstance(member.type, AbstractNestedType) and isinstance(member.type.value_type, BasicType) and member.type.value_type.typename in SPECIAL_NESTED_BASIC_TYPES]@
 @[    if isinstance(member.type, Array)]@


### PR DESCRIPTION
Companion to ros2/rosidl#946 (fixes ros2/ros2#1679)

## Summary

Adds `DeprecationWarning` support to the Python message generator for fields annotated with `@deprecated`.

## What this changes

### `rosidl_generator_py/resource/_msg.py.em`

For any field whose IDL `Member` carries a `@deprecated` annotation (set via `# @deprecated` in the `.msg` source), the generated Python property getter and setter now emit:

```python
import warnings
warnings.warn(
    "field 'old_field' in 'MyMessage' is deprecated",
    DeprecationWarning,
    stacklevel=2)
```

This fires at runtime whenever user code reads or writes the deprecated field, following standard Python deprecation convention (`stacklevel=2` points the warning at the caller, not the generated code).

## Coverage

The `_msg.py.em` template is the single leaf template invoked for all message-like types — messages, service request/response/event sub-messages, and action goal/result/feedback sub-messages — so the warning propagates automatically to `.srv` and `.action` fields as well.

## Known limitations / out of scope
- **Whole-message deprecation** is not addressed here; only field-level.
- **No custom deprecation message** — `# @deprecated` carries no free-text argument in this version.
- **Wire format is unchanged** — `@deprecated` does not affect type hash or serialization.
