### PR TITLE
rosidl_generator_py_generate_interfaces: link Python3::Module instead of Python3::Python

### DIFF
--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -164,7 +164,7 @@ add_dependencies(
 target_link_libraries(
   ${_target_name_lib} PRIVATE
   Python3::NumPy
-  Python3::Python
+  Python3::Module
 )
 target_include_directories(${_target_name_lib}
   PRIVATE


### PR DESCRIPTION
## Description

When linking a Python loadable module (or a shared library that will be linked by a Python loadable module), CMake suggest to link `Python3::Module` instead of `Python3::Python`, see https://cmake.org/cmake/help/latest/module/FindPython.html. In particular, `Python3::Python` is described as:

> Python library for Python embedding.

while `Python3::Module` is described as:

> Python library for Python module.

Why is this necessary? There is not a big difference on any platform, except on macOS when using a Python interpreter that statically link `libpython`. In that case, linking to `Python3::Module` ensure that there are no segfaults when the corresponding Python module is loaded in the Python interpreter.

See some related issues on this:
* https://github.com/robotology/icub-main/pull/987
* https://github.com/RoboStack/ros-humble/issues/119
* https://github.com/astral-sh/python-build-standalone/pull/540#issuecomment-2687182625
* https://github.com/AprilRobotics/apriltag/issues/352
* https://github.com/PixarAnimationStudios/OpenUSD/issues/2371
* https://github.com/conda-forge/python-feedstock/issues/595
* https://github.com/ros2/rclpy/pull/1305
* https://github.com/ros2/rosbag2/pull/1929


Fixes # (issue)

### Is this user-facing behavior change?

No, it is not a user-facing behaviour change.

### Did you use Generative AI?

No.

### Additional Information

This is one of the long standing patches that we carry on in RoboStack, I am not sure why we never upstreamed it.