### PR TITLE
Feature: add depends flag for ament_python_install_package

### DIFF
--- a/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
+++ b/rosidl_generator_py/cmake/rosidl_generator_py_generate_interfaces.cmake
@@ -134,11 +134,12 @@ rosidl_write_generator_arguments(
   TARGET_DEPENDENCIES ${target_dependencies}
 )
 
-if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
-  ament_python_install_package(${PROJECT_NAME} PACKAGE_DIR "${_output_path}")
-endif()
-
 set(_target_suffix "__py")
+
+if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
+  ament_python_install_package(${PROJECT_NAME} PACKAGE_DIR "${_output_path}"
+  DEPENDS ${rosidl_generate_interfaces_TARGET}${_target_suffix})
+endif()
 
 # move custom command into a subdirectory to avoid multiple invocations on Windows
 set(_subdir "${CMAKE_CURRENT_BINARY_DIR}/${rosidl_generate_interfaces_TARGET}${_target_suffix}")


### PR DESCRIPTION
Follows up to ament/ament_cmake#587 
Allow a cmake package to install both rosidl generated interfaces and a user written python package.

## Changes
Update rosidl_python to use the new DEPENDS argument added to ament_python_install_package.
This is required to assure installation happens only after the interface python modules are generated.
