### PR TITLE
Enable capability to build with pedantic flags.

### DIFF
--- a/rosidl_generator_py/resource/_idl_pkg_typesupport_entry_point.c.em
+++ b/rosidl_generator_py/resource/_idl_pkg_typesupport_entry_point.c.em
@@ -21,6 +21,19 @@ include_directives = set()
 register_functions = []
 }@
 #include <Python.h>
+#include <string.h>
+
+// Convert a function pointer to void * via memcpy for use with PyCapsule_New().
+static inline void *
+_funcptr_to_capsule_ptr(void (* fn)(void))
+{
+  _Static_assert(
+    sizeof(void *) == sizeof(fn),
+    "void * and function pointer must have the same size");
+  void * ptr;
+  memcpy(&ptr, &fn, sizeof(ptr));
+  return ptr;
+}
 
 static PyMethodDef @(package_name)__methods[] = {
   {NULL, NULL, 0, NULL}  /* sentinel */

--- a/rosidl_generator_py/resource/_msg_pkg_typesupport_entry_point.c.em
+++ b/rosidl_generator_py/resource/_msg_pkg_typesupport_entry_point.c.em
@@ -74,7 +74,7 @@ function_names = ['create_ros_message', 'destroy_ros_message', 'convert_from_py'
   PyObject * pyobject_@(function_name) = NULL;
   pyobject_@(function_name) = PyCapsule_New(
 @[    if function_name != 'type_support']@
-    (void *)&@('__'.join(message.structure.namespaced_type.namespaces + [module_name]))__@(function_name),
+    _funcptr_to_capsule_ptr((void (*)(void)) & @('__'.join(message.structure.namespaced_type.namespaces + [module_name]))__@(function_name)),
 @[    else]@
     (void *)ROSIDL_GET_MSG_TYPE_SUPPORT(@(', '.join(message.structure.namespaced_type.namespaced_name()))),
 @[    end if]@


### PR DESCRIPTION
## Description

* Let's say we have a `demo_pkg` as follows:
 
    ```bash
    .
    ├── CMakeLists.txt
    ├── msg
    │   └── Demo.msg
    └── package.xml
    ```
   `CMakeLists.txt`:
    ```txt
    cmake_minimum_required(VERSION 3.8)
    project(demo_pkg)
    
    find_package(ament_cmake REQUIRED)
    find_package(rosidl_default_generators REQUIRED)
    
    rosidl_generate_interfaces(${PROJECT_NAME}
      "msg/Demo.msg"
    )
    
    ament_package()
    ```   
   `package.xml`:
   ```xml
  <?xml version="1.0"?>
  <package format="3">
    <name>demo_pkg</name>
    <version>0.0.1</version>
    <description>Demo messages for testing -Wpedantic</description>
    <maintainer email="test@test.com">test</maintainer>
    <license>Apache-2.0</license>
  
    <buildtool_depend>ament_cmake</buildtool_depend>
    <buildtool_depend>rosidl_default_generators</buildtool_depend>
  
    <exec_depend>rosidl_default_runtime</exec_depend>
  
    <member_of_group>rosidl_interface_packages</member_of_group>
  </package>
  ```
  `Demo.msg`:
  ```txt
  string name
  ```
  
* Building with the `-Wpedantic` flag causes the following errors:

     ```bash
     $ colcon build --packages-select demo_pkg --cmake-args -DCMAKE_C_FLAGS="-Wpedantic -Werror"
     
    /ros2_ws/build/demo_msgs/rosidl_generator_py/demo_msgs/_demo_msgs_s.ep.rosidl_typesupport_c.c:59:5: warning: ISO C forbids conversion of function pointer to object pointer type [-Wpedantic]
       59 |     (void *)&demo_msgs__msg__demo__create_ros_message,
          |     ^
    /ros2_ws/build/demo_msgs/rosidl_generator_py/demo_msgs/_demo_msgs_s.ep.rosidl_typesupport_c.c:78:5: warning: ISO C forbids conversion of function pointer to object pointer type [-Wpedantic]
       78 |     (void *)&demo_msgs__msg__demo__destroy_ros_message,
          |     ^
    /ros2_ws/build/demo_msgs/rosidl_generator_py/demo_msgs/_demo_msgs_s.ep.rosidl_typesupport_c.c:97:5: warning: ISO C forbids conversion of function pointer to object pointer type [-Wpedantic]
       97 |     (void *)&demo_msgs__msg__demo__convert_from_py,
          |     ^
    /ros2_ws/build/demo_msgs/rosidl_generator_py/demo_msgs/_demo_msgs_s.ep.rosidl_typesupport_c.c:116:5: warning: ISO C forbids conversion of function pointer to object pointer type [-Wpedantic]
      116 |     (void *)&demo_msgs__msg__demo__convert_to_py,
     ```
* This is because `-Wpedantic` prevents casting a function pointer directly to `void *`.
* Therefore, instead of casting, the bytes of the function pointer are copied into a `void *` via `memcpy` through the added contribution.

* To test this fix, [rosidl](https://github.com/ros2/rosidl) and [rosidl_typesupport_fastrps](https://github.com/ros2/rosidl_typesupport_fastrtps) needs to compiled from source.


### Fixes # (issue)
* This enables the capability to build packages with the pedantic warning flag enabled.


### Is this user-facing behavior change?

Yes, it is a user-facing behavior change, as now new packages can be passed with - `--cmake-args -DCMAKE_C_FLAGS="-Wpedantic"`

### Did you use Generative AI?

* N/A

### Additional Information

* N/A
