### PR TITLE
perf: clear generated primitive arrays with slice deletion

### DIFF
--- a/rosidl_generator_py/resource/_msg_support.c.em
+++ b/rosidl_generator_py/resource/_msg_support.c.em
@@ -678,25 +678,15 @@ if isinstance(type_, AbstractNestedType):
 @(bi)      Py_DECREF(field);
 @(bi)      return NULL;
 @(bi)    }
-@(bi)    // clear the array, poor approach to remove potential default values
+@(bi)    // clear the array to remove potential default values
 @(bi)    Py_ssize_t length = PyObject_Length(field);
 @(bi)    if (-1 == length) {
 @(bi)      Py_DECREF(field);
 @(bi)      return NULL;
 @(bi)    }
-@(bi)    if (length > 0) {
-@(bi)      PyObject * pop = PyObject_GetAttrString(field, "pop");
-@(bi)      assert(pop != NULL);
-@(bi)      for (Py_ssize_t i = 0; i < length; ++i) {
-@(bi)        PyObject * ret = PyObject_CallFunctionObjArgs(pop, NULL);
-@(bi)        if (!ret) {
-@(bi)          Py_DECREF(pop);
-@(bi)          Py_DECREF(field);
-@(bi)          return NULL;
-@(bi)        }
-@(bi)        Py_DECREF(ret);
-@(bi)      }
-@(bi)      Py_DECREF(pop);
+@(bi)    if (PySequence_DelSlice(field, 0, length) == -1) {
+@(bi)      Py_DECREF(field);
+@(bi)      return NULL;
 @(bi)    }
 @(bi)    if (ros_message->@(member.name).size > 0) {
 @(bi)      // populating the array.array using the frombytes method

--- a/rosidl_generator_py/test/test_interfaces.py
+++ b/rosidl_generator_py/test/test_interfaces.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 import array
+import ctypes
 import math
 import sys
+from typing import Any
 
 import numpy
 import pytest
@@ -37,6 +39,48 @@ from rosidl_parser.definition import BoundedString
 from rosidl_parser.definition import NamespacedType
 from rosidl_parser.definition import UnboundedSequence
 from rosidl_parser.definition import UnboundedString
+
+
+_PY_CAPSULE_GET_POINTER = ctypes.pythonapi.PyCapsule_GetPointer
+_PY_CAPSULE_GET_POINTER.argtypes = [ctypes.py_object, ctypes.c_char_p]
+_PY_CAPSULE_GET_POINTER.restype = ctypes.c_void_p
+
+
+def _get_capsule_pointer(capsule: object) -> int:
+    pointer = _PY_CAPSULE_GET_POINTER(capsule, None)
+    assert pointer is not None
+    return pointer
+
+
+def _convert_through_type_support(message_type: Any, message: Any) -> Any:
+    message_type.__import_type_support__()
+    assert message_type._CREATE_ROS_MESSAGE is not None
+    assert message_type._CONVERT_FROM_PY is not None
+    assert message_type._CONVERT_TO_PY is not None
+    assert message_type._DESTROY_ROS_MESSAGE is not None
+
+    create_ros_message_type = ctypes.PYFUNCTYPE(ctypes.c_void_p)
+    convert_from_py_type = ctypes.PYFUNCTYPE(
+        ctypes.c_bool, ctypes.py_object, ctypes.c_void_p)
+    convert_to_py_type = ctypes.PYFUNCTYPE(ctypes.py_object, ctypes.c_void_p)
+    destroy_ros_message_type = ctypes.PYFUNCTYPE(None, ctypes.c_void_p)
+
+    create_ros_message = create_ros_message_type(
+        _get_capsule_pointer(message_type._CREATE_ROS_MESSAGE))
+    convert_from_py = convert_from_py_type(
+        _get_capsule_pointer(message_type._CONVERT_FROM_PY))
+    convert_to_py = convert_to_py_type(
+        _get_capsule_pointer(message_type._CONVERT_TO_PY))
+    destroy_ros_message = destroy_ros_message_type(
+        _get_capsule_pointer(message_type._DESTROY_ROS_MESSAGE))
+
+    ros_message = create_ros_message()
+    assert ros_message is not None
+    try:
+        assert convert_from_py(message, ros_message)
+        return convert_to_py(ros_message)
+    finally:
+        destroy_ros_message(ros_message)
 
 
 def test_basic_types() -> None:
@@ -763,6 +807,33 @@ def test_bounded_sequences() -> None:
     msg.bool_values = (True, False)
     assert isinstance(msg.bool_values, list)
     assert msg.bool_values == [True, False]
+
+
+@pytest.mark.parametrize(
+    ('message_type', 'field_name', 'type_code', 'values'),
+    (
+        (BoundedSequences, 'char_values', 'B', [0, 1, 255]),
+        (BoundedSequences, 'float32_values', 'f', [0.0, 1.25, -2.5]),
+        (BoundedSequences, 'int16_values', 'h', [0, -32768, 32767]),
+        (UnboundedSequences, 'uint16_values', 'H', [0, 1, 65535]),
+        (UnboundedSequences, 'int32_values', 'l', [0, -2147483648, 2147483647]),
+        (UnboundedSequences, 'uint64_values', 'Q', [0, 1, 18446744073709551615]),
+    ),
+)
+def test_primitive_sequences_convert_to_py(
+    message_type: Any,
+    field_name: str,
+    type_code: str,
+    values: list[Any],
+) -> None:
+    msg = message_type(check_fields=True)
+    setattr(msg, field_name, values)
+
+    converted_msg = _convert_through_type_support(message_type, msg)
+    converted_field = getattr(converted_msg, field_name)
+
+    assert converted_field.typecode == type_code
+    assert converted_field == array.array(type_code, values)
 
 
 def test_unbounded_sequences() -> None:


### PR DESCRIPTION
## Summary

Replace the generated Python array reset loop with `PySequence_DelSlice()` when converting primitive sequences to Python, and add regression coverage for bounded and unbounded primitive sequence conversion.

Closes #255

<details>
<summary>Before</summary>

```console
$ git show upstream/rolling:rosidl_generator_py/resource/_msg_support.c.em | sed -n "675,705p"
@(bi)    Py_DECREF(itemsize_attr);
@(bi)    if (itemsize != sizeof(@primitive_msg_type_to_c(member.type.value_type))) {
@(bi)      PyErr_SetString(PyExc_RuntimeError, "itemsize doesn't match expectation");
@(bi)      Py_DECREF(field);
@(bi)      return NULL;
@(bi)    }
@(bi)    // clear the array, poor approach to remove potential default values
@(bi)    Py_ssize_t length = PyObject_Length(field);
@(bi)    if (-1 == length) {
@(bi)      Py_DECREF(field);
@(bi)      return NULL;
@(bi)    }
@(bi)    if (length > 0) {
@(bi)      PyObject * pop = PyObject_GetAttrString(field, "pop");
@(bi)      assert(pop != NULL);
@(bi)      for (Py_ssize_t i = 0; i < length; ++i) {
@(bi)        PyObject * ret = PyObject_CallFunctionObjArgs(pop, NULL);
@(bi)        if (!ret) {
@(bi)          Py_DECREF(pop);
@(bi)          Py_DECREF(field);
@(bi)          return NULL;
@(bi)        }
@(bi)        Py_DECREF(ret);
@(bi)      }
@(bi)      Py_DECREF(pop);
@(bi)    }
@(bi)    if (ros_message->@(member.name).size > 0) {
@(bi)      // populating the array.array using the frombytes method
@(bi)      PyObject * frombytes = PyObject_GetAttrString(field, "frombytes");
@(bi)      assert(frombytes != NULL);
@(bi)      @primitive_msg_type_to_c(member.type.value_type) * src = &(ros_message->@(member.name).data[0]);

$ git show upstream/rolling:rosidl_generator_py/test/test_interfaces.py | rg -n "convert_to_py|PyCapsule|primitive_sequences_convert" || true
```

</details>

<details>
<summary>After</summary>

```console
$ git diff --check

$ python3 -m py_compile rosidl_generator_py/test/test_interfaces.py
$WORKSPACE/python310_torch25_cuda/lib/python3.10/site-packages/xpytorch_import_hook.py:6: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources

$ ruff check rosidl_generator_py/test/test_interfaces.py
All checks passed!

$ rg -n "PySequence_DelSlice|primitive_sequences_convert_to_py|PyCapsule_GetPointer" rosidl_generator_py/resource/_msg_support.c.em rosidl_generator_py/test/test_interfaces.py
rosidl_generator_py/test/test_interfaces.py:44:_PY_CAPSULE_GET_POINTER = ctypes.pythonapi.PyCapsule_GetPointer
rosidl_generator_py/test/test_interfaces.py:823:def test_primitive_sequences_convert_to_py(
rosidl_generator_py/resource/_msg_support.c.em:687:@(bi)    if (PySequence_DelSlice(field, 0, length) == -1) {

$ python -m pytest -q rosidl_generator_py/test/test_interfaces.py::test_primitive_sequences_convert_to_py
ERROR: found no collectors for $WORKSPACE/ros2-contrib/worktrees/rosidl_python-255/rosidl_generator_py/test/test_interfaces.py::test_primitive_sequences_convert_to_py


==================================== ERRORS ====================================
___________________ ERROR collecting test/test_interfaces.py ___________________
ImportError while importing test module '$WORKSPACE/ros2-contrib/worktrees/rosidl_python-255/rosidl_generator_py/test/test_interfaces.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../python310_torch25_cuda/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
rosidl_generator_py/test/test_interfaces.py:24: in <module>
    from rosidl_generator_py.msg import Arrays
E   ModuleNotFoundError: No module named 'rosidl_generator_py.msg'
=========================== short test summary info ============================
ERROR rosidl_generator_py/test/test_interfaces.py
1 error in 0.10s
```

</details>

## Test plan

- [x] `git diff --check`
- [x] `python3 -m py_compile rosidl_generator_py/test/test_interfaces.py`
- [x] `ruff check rosidl_generator_py/test/test_interfaces.py`
- [ ] Target pytest cannot complete in this local environment because `rosidl_generator_py.msg` is generated by the ROS build/test setup and is not present in this source checkout
